### PR TITLE
fix: set faststream log level on logger before injecting into broker

### DIFF
--- a/lite_bootstrap/bootstrappers/faststream_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/faststream_bootstrapper.py
@@ -109,8 +109,9 @@ class FastStreamLoggingInstrument(LoggingInstrument):
         super().bootstrap()
         broker = self.bootstrap_config.application.broker
         if broker is not None and import_checker.is_structlog_installed and import_checker.is_faststream_installed:
-            broker.config.logger.params_storage = ManualLoggerStorage(structlog.get_logger("faststream"))
-            broker.config.logger.set_level(self.bootstrap_config.faststream_log_level)
+            logger = structlog.get_logger("faststream")
+            logger.setLevel(self.bootstrap_config.faststream_log_level)
+            broker.config.logger.params_storage = ManualLoggerStorage(logger)
 
 
 @dataclasses.dataclass(kw_only=True, frozen=True)

--- a/tests/test_faststream_bootstrap.py
+++ b/tests/test_faststream_bootstrap.py
@@ -99,7 +99,7 @@ def test_faststream_logging_instrument_injects_structlog_logger(broker: RedisBro
     bootstrapper.bootstrap()
     try:
         assert isinstance(broker.config.logger.params_storage, ManualLoggerStorage)
-        assert broker.config.logger.log_level == logging.WARNING
+        assert logging.getLogger("faststream").level == logging.WARNING
     finally:
         bootstrapper.teardown()
 


### PR DESCRIPTION
LoggerState.set_level() was being called after assigning ManualLoggerStorage, which set both the underlying logger threshold AND LoggerState.log_level to WARNING. Since FastStream logs Received/Processed without an explicit level, it used LoggerState.log_level — so messages were submitted at WARNING and passed the filter.

Fix: call setLevel() on the structlog logger directly before passing to ManualLoggerStorage, leaving LoggerState.log_level at its INFO default. Messages are then submitted at INFO and dropped by filter_by_level against the WARNING threshold.