### PR TITLE
fix: shut down TracerProvider in OpenTelemetryInstrument.teardown

### DIFF
--- a/lite_bootstrap/instruments/opentelemetry_instrument.py
+++ b/lite_bootstrap/instruments/opentelemetry_instrument.py
@@ -78,6 +78,9 @@ class OpenTelemetryInstrument(BaseInstrument):
     bootstrap_config: OpentelemetryConfig
     not_ready_message = "opentelemetry_endpoint is empty and opentelemetry_log_traces is False"
     missing_dependency_message = "opentelemetry is not installed"
+    _tracer_provider: "TracerProvider | None" = dataclasses.field(
+        default_factory=lambda: None, init=False, repr=False, compare=False
+    )
 
     def is_ready(self) -> bool:
         return (
@@ -105,6 +108,7 @@ class OpenTelemetryInstrument(BaseInstrument):
         )
         tracer_provider = TracerProvider(resource=resource)
         set_tracer_provider(tracer_provider)
+        object.__setattr__(self, "_tracer_provider", tracer_provider)
         if import_checker.is_pyroscope_installed and getattr(self.bootstrap_config, "pyroscope_endpoint", None):
             tracer_provider.add_span_processor(PyroscopeSpanProcessor())
         if self.bootstrap_config.opentelemetry_log_traces:
@@ -133,3 +137,6 @@ class OpenTelemetryInstrument(BaseInstrument):
                 one_instrumentor.instrumentor.uninstrument(**one_instrumentor.additional_params)
             else:
                 one_instrumentor.uninstrument()
+        if self._tracer_provider is not None:
+            self._tracer_provider.shutdown()
+            object.__setattr__(self, "_tracer_provider", None)

--- a/tests/instruments/test_opentelemetry_instrument.py
+++ b/tests/instruments/test_opentelemetry_instrument.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from lite_bootstrap.instruments.opentelemetry_instrument import (
     InstrumentorWithParams,
     OpentelemetryConfig,
@@ -32,3 +34,18 @@ def test_opentelemetry_instrument_empty_instruments() -> None:
         opentelemetry_instrument.bootstrap()
     finally:
         opentelemetry_instrument.teardown()
+
+
+def test_opentelemetry_instrument_teardown_shuts_down_tracer_provider() -> None:
+    instrument = OpenTelemetryInstrument(
+        bootstrap_config=OpentelemetryConfig(opentelemetry_log_traces=True),
+    )
+    instrument.bootstrap()
+    tracer_provider = instrument._tracer_provider  # noqa: SLF001
+    assert tracer_provider is not None
+
+    with patch.object(tracer_provider, "shutdown") as mock_shutdown:
+        instrument.teardown()
+
+    mock_shutdown.assert_called_once_with()
+    assert instrument._tracer_provider is None  # noqa: SLF001


### PR DESCRIPTION
## Summary
- `OpenTelemetryInstrument.bootstrap()` now stashes the `TracerProvider` it created on the instance (via `object.__setattr__`, mirroring `LoggingInstrument._logger_factory`).
- `teardown()` calls `self._tracer_provider.shutdown()` after the existing instrumentor uninstrument loop, then resets the field to `None`. Spans buffered in `BatchSpanProcessor` now flush on graceful shutdown.
- New regression test `test_opentelemetry_instrument_teardown_shuts_down_tracer_provider` patches `shutdown` on the stashed provider and asserts it's invoked once and the field resets. Test fails on `main`, passes on this branch.

Closes CRIT-2 and TEST-2 from an internal audit of the codebase.

## Test plan
- [x] `just test -- tests/instruments/test_opentelemetry_instrument.py -v` — three tests pass.
- [x] `just test` — full suite 80/80.
- [x] `just lint` — clean (eof-fixer, ruff format, ruff check, ty check).
- [x] Reviewer: confirm the field declaration and `object.__setattr__` usage match the `LoggingInstrument._logger_factory` precedent.

## Known follow-up
If `shutdown()` raises, `_tracer_provider` is left non-None — same shape as `LoggingInstrument.teardown` (also a pre-existing pattern). The follow-up idempotency work (a separate PR addressing CRIT-3 from the audit) should wrap both teardowns in `try/finally` so a failed shutdown still resets the cached reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)