### PR TITLE
fix: make teardown idempotent and exception-safe

### DIFF
--- a/lite_bootstrap/bootstrappers/base.py
+++ b/lite_bootstrap/bootstrappers/base.py
@@ -80,6 +80,8 @@ class BaseBootstrapper(abc.ABC, typing.Generic[ApplicationT]):
         return self._prepare_application()
 
     def teardown(self) -> None:
+        if not self.is_bootstrapped:
+            return
         self.is_bootstrapped = False
         errors: list[tuple[str, BaseException]] = []
         for one_instrument in reversed(self.instruments):

--- a/lite_bootstrap/instruments/logging_instrument.py
+++ b/lite_bootstrap/instruments/logging_instrument.py
@@ -207,5 +207,7 @@ class LoggingInstrument(BaseInstrument):
             h.close()
         root_logger.setLevel(logging.WARNING)
         if self._logger_factory is not None:
-            self._logger_factory.close_handlers()
-            object.__setattr__(self, "_logger_factory", None)
+            try:
+                self._logger_factory.close_handlers()
+            finally:
+                object.__setattr__(self, "_logger_factory", None)

--- a/lite_bootstrap/instruments/opentelemetry_instrument.py
+++ b/lite_bootstrap/instruments/opentelemetry_instrument.py
@@ -138,5 +138,7 @@ class OpenTelemetryInstrument(BaseInstrument):
             else:
                 one_instrumentor.uninstrument()
         if self._tracer_provider is not None:
-            self._tracer_provider.shutdown()
-            object.__setattr__(self, "_tracer_provider", None)
+            try:
+                self._tracer_provider.shutdown()
+            finally:
+                object.__setattr__(self, "_tracer_provider", None)

--- a/tests/instruments/test_logging_instrument.py
+++ b/tests/instruments/test_logging_instrument.py
@@ -1,6 +1,8 @@
 import logging
 from io import StringIO
+from unittest.mock import patch
 
+import pytest
 import structlog
 from opentelemetry.trace import get_tracer
 
@@ -117,3 +119,20 @@ def test_memory_logger_factory_error() -> None:
     error_message = "error message"
     test_logger.error(error_message)
     assert error_message in test_stream.getvalue()
+
+
+def test_logging_instrument_teardown_resets_factory_when_close_handlers_raises() -> None:
+    instrument = LoggingInstrument(
+        bootstrap_config=LoggingConfig(logging_buffer_capacity=0),
+    )
+    instrument.bootstrap()
+    factory = instrument._logger_factory  # noqa: SLF001
+    assert factory is not None
+
+    with (
+        patch.object(factory, "close_handlers", side_effect=RuntimeError("boom")),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        instrument.teardown()
+
+    assert instrument._logger_factory is None  # noqa: SLF001

--- a/tests/instruments/test_opentelemetry_instrument.py
+++ b/tests/instruments/test_opentelemetry_instrument.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from lite_bootstrap.instruments.opentelemetry_instrument import (
     InstrumentorWithParams,
     OpentelemetryConfig,
@@ -48,4 +50,21 @@ def test_opentelemetry_instrument_teardown_shuts_down_tracer_provider() -> None:
         instrument.teardown()
 
     mock_shutdown.assert_called_once_with()
+    assert instrument._tracer_provider is None  # noqa: SLF001
+
+
+def test_opentelemetry_instrument_teardown_resets_tracer_provider_when_shutdown_raises() -> None:
+    instrument = OpenTelemetryInstrument(
+        bootstrap_config=OpentelemetryConfig(opentelemetry_log_traces=True),
+    )
+    instrument.bootstrap()
+    tracer_provider = instrument._tracer_provider  # noqa: SLF001
+    assert tracer_provider is not None
+
+    with (
+        patch.object(tracer_provider, "shutdown", side_effect=RuntimeError("boom")),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        instrument.teardown()
+
     assert instrument._tracer_provider is None  # noqa: SLF001

--- a/tests/test_free_bootstrap.py
+++ b/tests/test_free_bootstrap.py
@@ -108,3 +108,19 @@ def test_free_bootstrapper_with_missing_instrument_dependency(
 ) -> None:
     with emulate_package_missing(package_name), pytest.warns(UserWarning, match=package_name):
         FreeBootstrapper(bootstrap_config=free_bootstrapper_config)
+
+
+def test_teardown_is_idempotent(free_bootstrapper_config: FreeBootstrapperConfig) -> None:
+    bootstrapper = FreeBootstrapper(bootstrap_config=free_bootstrapper_config)
+    bootstrapper.bootstrap()
+
+    first = MagicMock()
+    second = MagicMock()
+    bootstrapper.instruments = [first, second]
+
+    bootstrapper.teardown()
+    bootstrapper.teardown()
+
+    first.teardown.assert_called_once()
+    second.teardown.assert_called_once()
+    assert not bootstrapper.is_bootstrapped


### PR DESCRIPTION
## Summary
Three teardown-robustness fixes bundled into one PR:

1. **`BaseBootstrapper.teardown()` idempotent.** Two-line guard at the top — returns immediately when `not self.is_bootstrapped`. Fixes the Litestar/FastStream case where the bootstrapper registers `self.teardown` on a framework shutdown hook *and* gets called manually, otherwise double-tearing-down instruments (many of which aren't idempotent themselves).
2. **`OpenTelemetryInstrument.teardown()` exception-safe.** Wraps `self._tracer_provider.shutdown()` in `try/finally` so the cached `_tracer_provider` resets even when shutdown raises.
3. **`LoggingInstrument.teardown()` exception-safe.** Same `try/finally` shape around `self._logger_factory.close_handlers()`.

Three regression tests added (one per fix); all fail on `main`, pass on this branch.

Closes CRIT-3 and TEST-3 from an internal audit. Resolves the follow-up flagged in PR #90's code review.

## Test plan
- [x] `just test -- tests/test_free_bootstrap.py -v` — all teardown tests pass.
- [x] `just test -- tests/instruments/test_opentelemetry_instrument.py -v` — pass.
- [x] `just test -- tests/instruments/test_logging_instrument.py -v` — pass.
- [x] `just test` — 83/83.
- [x] `just lint` — clean.
- [x] Reviewer: confirm the bootstrapper guard placement (top of teardown, **before** \`is_bootstrapped = False\`) — order matters so the second call observes \`is_bootstrapped\` as \`False\` from the first call.

## Notes for reviewer
- The two \`try/finally\` blocks use bare \`finally:\` with no \`except\`. The original exception propagates; the reset always runs.
- A \`bootstrap → teardown → bootstrap → teardown\` cycle is implicitly supported: the second \`bootstrap()\` sets \`is_bootstrapped = True\`, re-enabling the next teardown. Not explicitly tested in this PR; a one-liner extension would close that gap if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)