### PR TITLE
fix: strip skip_sentry from Sentry context; drop dead is_X_installed conjuncts

### DIFF
--- a/lite_bootstrap/instruments/logging_instrument.py
+++ b/lite_bootstrap/instruments/logging_instrument.py
@@ -137,7 +137,7 @@ class LoggingInstrument(BaseInstrument):
         ]
 
     def is_ready(self) -> bool:
-        return self.bootstrap_config.logging_enabled and import_checker.is_structlog_installed
+        return self.bootstrap_config.logging_enabled
 
     @staticmethod
     def check_dependencies() -> bool:

--- a/lite_bootstrap/instruments/opentelemetry_instrument.py
+++ b/lite_bootstrap/instruments/opentelemetry_instrument.py
@@ -83,10 +83,7 @@ class OpenTelemetryInstrument(BaseInstrument):
     )
 
     def is_ready(self) -> bool:
-        return (
-            bool(self.bootstrap_config.opentelemetry_endpoint or self.bootstrap_config.opentelemetry_log_traces)
-            and import_checker.is_opentelemetry_installed
-        )
+        return bool(self.bootstrap_config.opentelemetry_endpoint or self.bootstrap_config.opentelemetry_log_traces)
 
     @staticmethod
     def check_dependencies() -> bool:

--- a/lite_bootstrap/instruments/pyroscope_instrument.py
+++ b/lite_bootstrap/instruments/pyroscope_instrument.py
@@ -26,7 +26,7 @@ class PyroscopeInstrument(BaseInstrument):
     missing_dependency_message = "pyroscope is not installed"
 
     def is_ready(self) -> bool:
-        return bool(self.bootstrap_config.pyroscope_endpoint) and import_checker.is_pyroscope_installed
+        return bool(self.bootstrap_config.pyroscope_endpoint)
 
     @staticmethod
     def check_dependencies() -> bool:

--- a/lite_bootstrap/instruments/sentry_instrument.py
+++ b/lite_bootstrap/instruments/sentry_instrument.py
@@ -17,7 +17,7 @@ if import_checker.is_sentry_installed:
 
 
 IGNORED_STRUCTLOG_ATTRIBUTES: typing.Final = frozenset(
-    {"event", "level", "logger", "tracing", "timestamp", "exception"}
+    {"event", "level", "logger", "tracing", "timestamp", "exception", "skip_sentry"}
 )
 
 
@@ -98,7 +98,7 @@ class SentryInstrument(BaseInstrument):
     missing_dependency_message = "sentry_sdk is not installed"
 
     def is_ready(self) -> bool:
-        return bool(self.bootstrap_config.sentry_dsn) and import_checker.is_sentry_installed
+        return bool(self.bootstrap_config.sentry_dsn)
 
     @staticmethod
     def check_dependencies() -> bool:

--- a/tests/instruments/test_sentry_instrument.py
+++ b/tests/instruments/test_sentry_instrument.py
@@ -108,6 +108,16 @@ class TestSentryEnrichEventFromStructlog:
                     "contexts": {"structlog": {"foo": "bar"}},
                 },
             ),
+            (
+                {
+                    "logentry": {"formatted": '{"event": "event name", "skip_sentry": false, "foo": "bar"}'},
+                    "contexts": {},
+                },
+                {
+                    "logentry": {"formatted": "event name"},
+                    "contexts": {"structlog": {"foo": "bar"}},
+                },
+            ),
         ],
     )
     def test_modify(self, event_before: "sentry_types.Event", event_after: "sentry_types.Event") -> None:


### PR DESCRIPTION
## Summary
Two small audit cleanups bundled:

- **DES-4 (Sentry):** `skip_sentry` was already triggering event suppression when truthy, but for falsy values (False/missing/"") the flag itself wasn't stripped from the structlog payload and ended up as noise in `event["contexts"]["structlog"]`. Add `"skip_sentry"` to `IGNORED_STRUCTLOG_ATTRIBUTES`. Regression added as a parametrize case on the existing `test_modify`.
- **DES-5 (dead conjuncts):** Four instruments' `is_ready()` methods ended with `and import_checker.is_X_installed`. That conjunct is provably unreachable — `BaseBootstrapper._register_or_skip` calls `check_dependencies()` first and only invokes `is_ready()` if it returned True. Behavior is unchanged; cleanup makes the lifecycle easier to reason about.

Closes DES-4 and DES-5 from an internal audit.

## Test plan
- [x] `just test -- tests/instruments/test_sentry_instrument.py -v` — all parametrize cases pass.
- [x] `just test` — full suite 84/84.
- [x] `just lint` — clean (no F401 unused-import warnings; `import_checker` still used by `check_dependencies()` in every instrument).
- [x] Reviewer: confirm the DES-5 invariant by reading `lite_bootstrap/bootstrappers/base.py:44-64` — `is_ready()` is only invoked on an instrument that already passed `check_dependencies()`.

## Notes for reviewer
- `import_checker` import statement remains in all four instrument files (still referenced by each `check_dependencies()` method).
- Code review surfaced one nice-to-have follow-up: adding a `skip_sentry: true` parametrize case to `test_modify` for unit-level coverage of the suppression path (the integration test `test_sentry_instrument_with_structlog_error` already covers it). Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)