### PR TITLE
docs: document and pin BaseConfig.from_dict / from_object semantics

### DIFF
--- a/lite_bootstrap/instruments/base.py
+++ b/lite_bootstrap/instruments/base.py
@@ -15,17 +15,15 @@ class BaseConfig:
 
     @classmethod
     def from_dict(cls, data: dict[str, typing.Any]) -> typing_extensions.Self:
+        """Build a config from a dict; unknown keys are silently dropped, explicit None overrides defaults."""
         field_names = {f.name for f in dataclasses.fields(cls)}
         return cls(**{k: v for k, v in data.items() if k in field_names})
 
     @classmethod
     def from_object(cls, obj: object) -> typing_extensions.Self:
-        prepared_data = {}
+        """Build a config by merging non-None attributes from obj; None or missing attributes fall back to defaults."""
         field_names = {f.name for f in dataclasses.fields(cls)}
-
-        for field in field_names:
-            if (value := getattr(obj, field, None)) is not None:
-                prepared_data[field] = value
+        prepared_data = {field: value for field in field_names if (value := getattr(obj, field, None)) is not None}
         return cls(**prepared_data)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,3 +49,46 @@ def test_config_from_object() -> None:
     short_config = BaseConfig.from_object(big_config)
     for field in dataclasses.fields(BaseConfig):
         assert getattr(short_config, field.name) == getattr(big_config, field.name)
+
+
+def test_from_object_skips_none_attribute() -> None:
+    @dataclasses.dataclass
+    class Source:
+        service_name: str | None = None
+        service_version: str = "2.0.0"
+
+    config = BaseConfig.from_object(Source())
+    assert config.service_name == "micro-service"
+    assert config.service_version == "2.0.0"
+
+
+def test_from_object_skips_missing_attribute() -> None:
+    class Source:
+        pass
+
+    config = BaseConfig.from_object(Source())
+    assert config.service_name == "micro-service"
+    assert config.service_version == "1.0.0"
+    assert config.service_debug is True
+
+
+def test_from_object_preserves_falsy_values() -> None:
+    @dataclasses.dataclass
+    class Source:
+        service_name: str = ""
+        service_debug: bool = False
+
+    config = BaseConfig.from_object(Source())
+    assert config.service_name == ""
+    assert config.service_debug is False
+
+
+def test_from_dict_drops_unknown_keys_silently() -> None:
+    config = BaseConfig.from_dict({"service_name": "test", "unknown_key": "value"})
+    assert config.service_name == "test"
+    assert config.service_version == "1.0.0"
+
+
+def test_from_dict_explicit_none_overrides_default() -> None:
+    config = BaseConfig.from_dict({"service_name": None})
+    assert config.service_name is None


### PR DESCRIPTION
## Summary
Documents the intentional asymmetry between `BaseConfig.from_dict` and `BaseConfig.from_object` (DES-3 from an internal audit):

- `from_dict` includes any key present in the dict; unknown keys are silently dropped; explicit `None` overrides defaults.
- `from_object` includes only attributes whose value is not `None` (`None` or missing falls back to dataclass defaults); falsy non-`None` values are preserved.

One-line docstrings added to each method. `from_object`'s body is also condensed from a 5-line imperative form to a single dict-comprehension matching `from_dict`'s style — functionally identical and locked in by the new pinning tests.

Five pinning tests added (closing TEST-5 and TEST-6 from the audit):
- `test_from_object_skips_none_attribute`
- `test_from_object_skips_missing_attribute`
- `test_from_object_preserves_falsy_values`
- `test_from_dict_drops_unknown_keys_silently`
- `test_from_dict_explicit_none_overrides_default`

These pass before and after the docstring additions — they pin existing behavior to prevent future regressions where someone "unifies" the two methods without realizing the asymmetry is intentional.

Closes DES-3, TEST-5, TEST-6 from an internal audit.

## Test plan
- [x] `just test -- tests/test_config.py -v` — seven tests pass.
- [x] `just test` — full suite 89/89.
- [x] `just lint` — clean.
- [x] Reviewer: confirm the `from_object` body condensation (5 lines → 1 dict-comprehension with walrus) is functionally identical. If you'd rather see the docstring change land without the body cleanup, request a revert — the pinning tests verify both forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)