### PR TITLE
refactor: extract OpenTelemetryServiceFieldsConfig mixin

### DIFF
--- a/lite_bootstrap/instruments/opentelemetry_instrument.py
+++ b/lite_bootstrap/instruments/opentelemetry_instrument.py
@@ -33,13 +33,17 @@ class InstrumentorWithParams:
 
 
 @dataclasses.dataclass(kw_only=True, frozen=True)
-class OpentelemetryConfig(BaseConfig):
+class OpenTelemetryServiceFieldsConfig(BaseConfig):
     opentelemetry_service_name: str | None = None
+    opentelemetry_namespace: str | None = None
+
+
+@dataclasses.dataclass(kw_only=True, frozen=True)
+class OpentelemetryConfig(OpenTelemetryServiceFieldsConfig):
     opentelemetry_container_name: str | None = dataclasses.field(
         default_factory=lambda: os.environ.get("HOSTNAME") or None
     )
     opentelemetry_endpoint: str | None = None
-    opentelemetry_namespace: str | None = None
     opentelemetry_insecure: bool = True
     opentelemetry_instrumentors: list[typing.Union[InstrumentorWithParams, "BaseInstrumentor"]] = dataclasses.field(
         default_factory=list

--- a/lite_bootstrap/instruments/pyroscope_instrument.py
+++ b/lite_bootstrap/instruments/pyroscope_instrument.py
@@ -2,7 +2,8 @@ import dataclasses
 import typing
 
 from lite_bootstrap import import_checker
-from lite_bootstrap.instruments.base import BaseConfig, BaseInstrument
+from lite_bootstrap.instruments.base import BaseInstrument
+from lite_bootstrap.instruments.opentelemetry_instrument import OpenTelemetryServiceFieldsConfig
 
 
 if import_checker.is_pyroscope_installed:
@@ -10,13 +11,11 @@ if import_checker.is_pyroscope_installed:
 
 
 @dataclasses.dataclass(kw_only=True, frozen=True)
-class PyroscopeConfig(BaseConfig):
+class PyroscopeConfig(OpenTelemetryServiceFieldsConfig):
     pyroscope_endpoint: str | None = None
     pyroscope_sample_rate: int = 100
     pyroscope_tags: dict[str, str] = dataclasses.field(default_factory=dict)
     pyroscope_additional_params: dict[str, typing.Any] = dataclasses.field(default_factory=dict)
-    opentelemetry_service_name: str | None = None
-    opentelemetry_namespace: str | None = None
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)


### PR DESCRIPTION
## Summary
`opentelemetry_service_name` and `opentelemetry_namespace` were declared identically on both `OpentelemetryConfig` and `PyroscopeConfig`. In the four framework configs (Free, FastAPI, Litestar, FastStream) that inherit from both parents, Python's MRO happened to pick one declaration; the fact that defaults matched is what kept behavior consistent. Without the mixin, drifting defaults on one side would silently misbehave on the framework configs.

Extract `OpenTelemetryServiceFieldsConfig(BaseConfig)` — a tiny mixin declaring just those two fields. Both `OpentelemetryConfig` and `PyroscopeConfig` now inherit from it (no longer from `BaseConfig` directly). The duplicate declarations are removed.

`PyroscopeConfig`'s standalone use case (without `OpentelemetryConfig` in the MRO) is preserved — exercised by `test_pyroscope_standalone_config_accepts_otel_fields`.

Closes DES-2 from an internal audit.

## Test plan
- [x] `just test -- tests/instruments/test_opentelemetry_instrument.py tests/instruments/test_pyroscope_instrument.py -v` — pass.
- [x] `just test` — full suite 89/89.
- [x] `just lint` — clean.
- [ ] Reviewer: confirm the new dependency direction (`pyroscope_instrument` → `opentelemetry_instrument`) is acceptable. Code review confirmed: no circular import — `opentelemetry_instrument` imports the `pyroscope` package, not `pyroscope_instrument`.

## Notes for reviewer
The MRO for `FreeBootstrapperConfig(LoggingConfig, OpentelemetryConfig, PyroscopeConfig, SentryConfig)` resolves as:
`FreeBootstrapperConfig → LoggingConfig → OpentelemetryConfig → PyroscopeConfig → OpenTelemetryServiceFieldsConfig → SentryConfig → BaseConfig → object`

`OpenTelemetryServiceFieldsConfig` appears exactly once via C3 linearization — both children share the same ancestor.

Cosmetic future-work note: `OpentelemetryConfig` (lowercase `t`) sits next to the new `OpenTelemetryServiceFieldsConfig` (uppercase `T`) — same module, different casing. Worth a rename + deprecation alias in a follow-up PR. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)