### PR TITLE
refactor: make BaseInstrument generic; delete pure-annotation subclasses

### DIFF
--- a/lite_bootstrap/bootstrappers/fastapi_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/fastapi_bootstrapper.py
@@ -109,11 +109,6 @@ class FastAPIHealthChecksInstrument(HealthChecksInstrument):
 
 
 @dataclasses.dataclass(kw_only=True, frozen=True)
-class FastAPILoggingInstrument(LoggingInstrument):
-    bootstrap_config: FastAPIConfig
-
-
-@dataclasses.dataclass(kw_only=True, frozen=True)
 class FastAPIOpenTelemetryInstrument(OpenTelemetryInstrument):
     bootstrap_config: FastAPIConfig
 
@@ -136,11 +131,6 @@ class FastAPIOpenTelemetryInstrument(OpenTelemetryInstrument):
     def teardown(self) -> None:
         FastAPIInstrumentor.uninstrument_app(self.bootstrap_config.application)
         super().teardown()
-
-
-@dataclasses.dataclass(kw_only=True, frozen=True)
-class FastAPISentryInstrument(SentryInstrument):
-    bootstrap_config: FastAPIConfig
 
 
 @dataclasses.dataclass(kw_only=True, frozen=True)
@@ -188,9 +178,9 @@ class FastAPIBootstrapper(BaseBootstrapper["fastapi.FastAPI"]):
         FastAPICorsInstrument,
         FastAPIOpenTelemetryInstrument,
         PyroscopeInstrument,
-        FastAPISentryInstrument,
+        SentryInstrument,
         FastAPIHealthChecksInstrument,
-        FastAPILoggingInstrument,
+        LoggingInstrument,
         FastAPIPrometheusInstrument,
         FastAPISwaggerInstrument,
     ]

--- a/lite_bootstrap/bootstrappers/faststream_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/faststream_bootstrapper.py
@@ -132,11 +132,6 @@ class FastStreamOpenTelemetryInstrument(OpenTelemetryInstrument):
             )
 
 
-@dataclasses.dataclass(kw_only=True, frozen=True)
-class FastStreamSentryInstrument(SentryInstrument):
-    bootstrap_config: FastStreamConfig
-
-
 def _make_collector_registry() -> "prometheus_client.CollectorRegistry":
     return prometheus_client.CollectorRegistry()
 
@@ -177,7 +172,7 @@ class FastStreamBootstrapper(BaseBootstrapper["AsgiFastStream"]):
     instruments_types: typing.ClassVar = [
         FastStreamOpenTelemetryInstrument,
         PyroscopeInstrument,
-        FastStreamSentryInstrument,
+        SentryInstrument,
         FastStreamHealthChecksInstrument,
         FastStreamLoggingInstrument,
         FastStreamPrometheusInstrument,

--- a/lite_bootstrap/bootstrappers/litestar_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/litestar_bootstrapper.py
@@ -197,11 +197,6 @@ class LitestarOpenTelemetryInstrument(OpenTelemetryInstrument):
 
 
 @dataclasses.dataclass(kw_only=True, frozen=True)
-class LitestarSentryInstrument(SentryInstrument):
-    bootstrap_config: LitestarConfig
-
-
-@dataclasses.dataclass(kw_only=True, frozen=True)
 class LitestarPrometheusInstrument(PrometheusInstrument):
     bootstrap_config: LitestarConfig
     missing_dependency_message = "prometheus_client is not installed"
@@ -271,7 +266,7 @@ class LitestarBootstrapper(BaseBootstrapper["litestar.Litestar"]):
         LitestarCorsInstrument,
         LitestarOpenTelemetryInstrument,
         PyroscopeInstrument,
-        LitestarSentryInstrument,
+        SentryInstrument,
         LitestarHealthChecksInstrument,
         LitestarLoggingInstrument,
         LitestarPrometheusInstrument,

--- a/lite_bootstrap/instruments/base.py
+++ b/lite_bootstrap/instruments/base.py
@@ -27,15 +27,18 @@ class BaseConfig:
         return cls(**prepared_data)
 
 
+ConfigT = typing.TypeVar("ConfigT", bound=BaseConfig)
+
+
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
-class BaseInstrument(abc.ABC):
-    bootstrap_config: BaseConfig
+class BaseInstrument(abc.ABC, typing.Generic[ConfigT]):
+    bootstrap_config: ConfigT
     not_ready_message = ""
     missing_dependency_message = ""
 
-    def bootstrap(self) -> None: ...  # noqa: B027
+    def bootstrap(self) -> None: ...
 
-    def teardown(self) -> None: ...  # noqa: B027
+    def teardown(self) -> None: ...
 
     def is_ready(self) -> bool:
         return True

--- a/lite_bootstrap/instruments/cors_instrument.py
+++ b/lite_bootstrap/instruments/cors_instrument.py
@@ -15,8 +15,7 @@ class CorsConfig(BaseConfig):
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
-class CorsInstrument(BaseInstrument):
-    bootstrap_config: CorsConfig
+class CorsInstrument(BaseInstrument[CorsConfig]):
     not_ready_message = "cors_allowed_origins or cors_allowed_origin_regex must be provided"
 
     def is_ready(self) -> bool:

--- a/lite_bootstrap/instruments/healthchecks_instrument.py
+++ b/lite_bootstrap/instruments/healthchecks_instrument.py
@@ -27,8 +27,7 @@ class HealthChecksConfig(BaseConfig):
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
-class HealthChecksInstrument(BaseInstrument):
-    bootstrap_config: HealthChecksConfig
+class HealthChecksInstrument(BaseInstrument[HealthChecksConfig]):
     not_ready_message = "health_checks_enabled is False"
 
     def is_ready(self) -> bool:

--- a/lite_bootstrap/instruments/logging_instrument.py
+++ b/lite_bootstrap/instruments/logging_instrument.py
@@ -115,8 +115,7 @@ class LoggingConfig(BaseConfig):
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
-class LoggingInstrument(BaseInstrument):
-    bootstrap_config: LoggingConfig
+class LoggingInstrument(BaseInstrument[LoggingConfig]):
     not_ready_message = "logging_enabled is False"
     missing_dependency_message = "structlog is not installed"
     _logger_factory: "MemoryLoggerFactory | None" = dataclasses.field(

--- a/lite_bootstrap/instruments/opentelemetry_instrument.py
+++ b/lite_bootstrap/instruments/opentelemetry_instrument.py
@@ -78,8 +78,7 @@ if import_checker.is_opentelemetry_installed and import_checker.is_pyroscope_ins
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
-class OpenTelemetryInstrument(BaseInstrument):
-    bootstrap_config: OpentelemetryConfig
+class OpenTelemetryInstrument(BaseInstrument[OpentelemetryConfig]):
     not_ready_message = "opentelemetry_endpoint is empty and opentelemetry_log_traces is False"
     missing_dependency_message = "opentelemetry is not installed"
     _tracer_provider: "TracerProvider | None" = dataclasses.field(

--- a/lite_bootstrap/instruments/prometheus_instrument.py
+++ b/lite_bootstrap/instruments/prometheus_instrument.py
@@ -11,8 +11,7 @@ class PrometheusConfig(BaseConfig):
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
-class PrometheusInstrument(BaseInstrument):
-    bootstrap_config: PrometheusConfig
+class PrometheusInstrument(BaseInstrument[PrometheusConfig]):
     not_ready_message = "prometheus_metrics_path is empty or not valid"
 
     def is_ready(self) -> bool:

--- a/lite_bootstrap/instruments/pyroscope_instrument.py
+++ b/lite_bootstrap/instruments/pyroscope_instrument.py
@@ -19,8 +19,7 @@ class PyroscopeConfig(OpenTelemetryServiceFieldsConfig):
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
-class PyroscopeInstrument(BaseInstrument):
-    bootstrap_config: PyroscopeConfig
+class PyroscopeInstrument(BaseInstrument[PyroscopeConfig]):
     not_ready_message = "pyroscope_endpoint is empty"
     missing_dependency_message = "pyroscope is not installed"
 

--- a/lite_bootstrap/instruments/sentry_instrument.py
+++ b/lite_bootstrap/instruments/sentry_instrument.py
@@ -92,8 +92,7 @@ def wrap_before_send_callbacks(
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
-class SentryInstrument(BaseInstrument):
-    bootstrap_config: SentryConfig
+class SentryInstrument(BaseInstrument[SentryConfig]):
     not_ready_message = "sentry_dsn is empty"
     missing_dependency_message = "sentry_sdk is not installed"
 

--- a/lite_bootstrap/instruments/swagger_instrument.py
+++ b/lite_bootstrap/instruments/swagger_instrument.py
@@ -11,5 +11,5 @@ class SwaggerConfig(BaseConfig):
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
-class SwaggerInstrument(BaseInstrument):
-    bootstrap_config: SwaggerConfig
+class SwaggerInstrument(BaseInstrument[SwaggerConfig]):
+    pass


### PR DESCRIPTION
## Summary
Closes DES-1 from an internal audit: the four pure type-annotation framework subclasses (`FastAPILoggingInstrument`, `FastAPISentryInstrument`, `LitestarSentryInstrument`, `FastStreamSentryInstrument`) existed only to narrow `bootstrap_config`. They contributed no behavior.

- `BaseInstrument` is now generic in `ConfigT` (`TypeVar` bound to `BaseConfig`).
- Each base instrument concretely parameterizes the generic (`LoggingInstrument(BaseInstrument[LoggingConfig])`, etc.) and drops its redundant `bootstrap_config` field declaration.
- The four pure-annotation framework subclasses are deleted. The three affected bootstrappers' `instruments_types` lists now reference base names directly (`SentryInstrument`, `LoggingInstrument`).
- Framework subclasses that override `bootstrap()` with framework-specific logic (15 total) keep their existing structure.

12 files modified, net **-24 lines**. No behavior change. Existing 89 tests verify correctness.

## Deviation from sequencing spec
The sequencing spec called for "dropping redundant `bootstrap_config:` annotations on kept subclasses." Under single-level generic those annotations are NOT redundant — they provide essential type narrowing for framework field access (e.g. `self.bootstrap_config.application` in `FastAPICorsInstrument.bootstrap()`). Making them truly redundant would require a two-level-generic design (each base instrument with its own bounded TypeVar); the complexity isn't worth the marginal cleanup. The audit's stated goal — eliminating the pure-annotation boilerplate — is fully addressed regardless.

## Test plan
- [x] `just test` — 89/89.
- [x] `just lint` — clean (`ty check` clean, `ruff check` clean).
- [x] `BaseInstrument`'s `slots=True` worked first try with Generic (no fallback needed).
- [x] No `# ty: ignore` comments required on framework subclasses' `bootstrap_config` re-annotations.
- [x] Reviewer: confirm the `# noqa: B027` removal is acceptable. Ruff stopped flagging `abc.ABC + Generic[T]` classes once Generic was added — the suppressions became genuinely unnecessary. `bootstrap()` and `teardown()` on `BaseInstrument` are still concrete no-ops (overridable but not required); they're not abstract.

## Notes for reviewer
- The 15 kept framework subclasses (`FastAPICorsInstrument`, `LitestarLoggingInstrument`, etc.) still declare `bootstrap_config: <FrameworkConfig>`. This is a covariant narrowing (`FrameworkConfig` is a subtype of `LoggingConfig`/`CorsConfig`/etc.) — standard dataclass pattern for narrowing inherited fields.
- `SwaggerInstrument` ended up with a `pass` body (only contained the dropped field declaration). Cosmetically odd but mechanically correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)