### PR TITLE
fix: tighten Sentry idiom and typing micro-issues

### DIFF
--- a/lite_bootstrap/instruments/sentry_instrument.py
+++ b/lite_bootstrap/instruments/sentry_instrument.py
@@ -33,7 +33,7 @@ class SentryConfig(BaseConfig):
     sentry_additional_params: dict[str, typing.Any] = dataclasses.field(default_factory=dict)
     sentry_tags: dict[str, str] | None = None
     sentry_default_integrations: bool = True
-    sentry_before_send: typing.Callable[[typing.Any, typing.Any], typing.Any | None] | None = None
+    sentry_before_send: "sentry_types.EventProcessor | None" = None
 
 
 def enrich_sentry_event_from_structlog_log(
@@ -78,7 +78,7 @@ def wrap_before_send_callbacks(
         event: "sentry_types.Event", hint: "sentry_types.Hint"
     ) -> typing.Optional["sentry_types.Event"]:
         for callback in callbacks:
-            if not callback:
+            if callback is None:
                 continue
 
             temp_event = callback(event, hint)


### PR DESCRIPTION
## Summary
Two micro-fixes in `sentry_instrument.py`:

- **LOW-1:** `wrap_before_send_callbacks` used `if not callback:` to skip `None` entries in `*callbacks`. Callables are always truthy unless they define `__bool__`, so the truthiness check is semantically wrong (happens to work for normal callables, but obscures the intent). Use `if callback is None:` to match the intent — also the PEP 8 canonical form for singleton checks.
- **LOW-2:** `SentryConfig.sentry_before_send` was annotated `Callable[[Any, Any], Any | None] | None`. The inner `Any | None` collapses to `Any`, so the annotation reduces to `Callable[..., Any] | None` — the union adds nothing. Use the proper `sentry_types.EventProcessor | None` (string-quoted; the type lives under `TYPE_CHECKING`).

No behavior change. No new tests — existing Sentry tests cover both paths.

Closes LOW-1 and LOW-2 from an internal audit.

## Test plan
- [x] `just test -- tests/instruments/test_sentry_instrument.py -v` — pass.
- [x] `just test` — 89/89.
- [x] `just lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)