### PR TITLE
refactor: rename OpentelemetryConfig → OpenTelemetryConfig; FreeBootstrapperConfig → FreeConfig

### DIFF
--- a/lite_bootstrap/__init__.py
+++ b/lite_bootstrap/__init__.py
@@ -1,6 +1,6 @@
 from lite_bootstrap.bootstrappers.fastapi_bootstrapper import FastAPIBootstrapper, FastAPIConfig
 from lite_bootstrap.bootstrappers.faststream_bootstrapper import FastStreamBootstrapper, FastStreamConfig
-from lite_bootstrap.bootstrappers.free_bootstrapper import FreeBootstrapper, FreeBootstrapperConfig
+from lite_bootstrap.bootstrappers.free_bootstrapper import FreeBootstrapper, FreeBootstrapperConfig, FreeConfig
 from lite_bootstrap.bootstrappers.litestar_bootstrapper import LitestarBootstrapper, LitestarConfig
 from lite_bootstrap.exceptions import (
     BootstrapperNotReadyError,
@@ -23,6 +23,7 @@ __all__ = [
     "FastStreamConfig",
     "FreeBootstrapper",
     "FreeBootstrapperConfig",
+    "FreeConfig",
     "InstrumentDependencyMissingWarning",
     "InstrumentNotReadyWarning",
     "InstrumentSkippedWarning",

--- a/lite_bootstrap/bootstrappers/fastapi_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/fastapi_bootstrapper.py
@@ -14,7 +14,7 @@ from lite_bootstrap.instruments.healthchecks_instrument import (
     HealthCheckTypedDict,
 )
 from lite_bootstrap.instruments.logging_instrument import LoggingConfig, LoggingInstrument
-from lite_bootstrap.instruments.opentelemetry_instrument import OpentelemetryConfig, OpenTelemetryInstrument
+from lite_bootstrap.instruments.opentelemetry_instrument import OpenTelemetryConfig, OpenTelemetryInstrument
 from lite_bootstrap.instruments.prometheus_instrument import PrometheusConfig, PrometheusInstrument
 from lite_bootstrap.instruments.pyroscope_instrument import PyroscopeConfig, PyroscopeInstrument
 from lite_bootstrap.instruments.sentry_instrument import SentryConfig, SentryInstrument
@@ -42,7 +42,7 @@ class FastAPIConfig(
     CorsConfig,
     HealthChecksConfig,
     LoggingConfig,
-    OpentelemetryConfig,
+    OpenTelemetryConfig,
     PrometheusConfig,
     PyroscopeConfig,
     SentryConfig,

--- a/lite_bootstrap/bootstrappers/faststream_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/faststream_bootstrapper.py
@@ -7,7 +7,7 @@ from lite_bootstrap import import_checker
 from lite_bootstrap.bootstrappers.base import BaseBootstrapper
 from lite_bootstrap.instruments.healthchecks_instrument import HealthChecksConfig, HealthChecksInstrument
 from lite_bootstrap.instruments.logging_instrument import LoggingConfig, LoggingInstrument
-from lite_bootstrap.instruments.opentelemetry_instrument import OpentelemetryConfig, OpenTelemetryInstrument
+from lite_bootstrap.instruments.opentelemetry_instrument import OpenTelemetryConfig, OpenTelemetryInstrument
 from lite_bootstrap.instruments.prometheus_instrument import PrometheusConfig, PrometheusInstrument
 from lite_bootstrap.instruments.pyroscope_instrument import PyroscopeConfig, PyroscopeInstrument
 from lite_bootstrap.instruments.sentry_instrument import SentryConfig, SentryInstrument
@@ -62,7 +62,7 @@ def _make_asgi_faststream() -> "AsgiFastStream":
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class FastStreamConfig(
-    HealthChecksConfig, LoggingConfig, OpentelemetryConfig, PrometheusConfig, PyroscopeConfig, SentryConfig
+    HealthChecksConfig, LoggingConfig, OpenTelemetryConfig, PrometheusConfig, PyroscopeConfig, SentryConfig
 ):
     application: "AsgiFastStream" = dataclasses.field(default_factory=_make_asgi_faststream)
     opentelemetry_middleware_cls: type[FastStreamTelemetryMiddlewareProtocol] | None = None

--- a/lite_bootstrap/bootstrappers/free_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/free_bootstrapper.py
@@ -3,13 +3,13 @@ import typing
 
 from lite_bootstrap.bootstrappers.base import BaseBootstrapper
 from lite_bootstrap.instruments.logging_instrument import LoggingConfig, LoggingInstrument
-from lite_bootstrap.instruments.opentelemetry_instrument import OpentelemetryConfig, OpenTelemetryInstrument
+from lite_bootstrap.instruments.opentelemetry_instrument import OpenTelemetryConfig, OpenTelemetryInstrument
 from lite_bootstrap.instruments.pyroscope_instrument import PyroscopeConfig, PyroscopeInstrument
 from lite_bootstrap.instruments.sentry_instrument import SentryConfig, SentryInstrument
 
 
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
-class FreeBootstrapperConfig(LoggingConfig, OpentelemetryConfig, PyroscopeConfig, SentryConfig): ...
+class FreeConfig(LoggingConfig, OpenTelemetryConfig, PyroscopeConfig, SentryConfig): ...
 
 
 class FreeBootstrapper(BaseBootstrapper[None]):
@@ -21,14 +21,18 @@ class FreeBootstrapper(BaseBootstrapper[None]):
         OpenTelemetryInstrument,
         PyroscopeInstrument,
     ]
-    bootstrap_config: FreeBootstrapperConfig
+    bootstrap_config: FreeConfig
     not_ready_message = ""
 
     def is_ready(self) -> bool:
         return True
 
-    def __init__(self, bootstrap_config: FreeBootstrapperConfig) -> None:
+    def __init__(self, bootstrap_config: FreeConfig) -> None:
         super().__init__(bootstrap_config)
 
     def _prepare_application(self) -> None:
         return None
+
+
+# Backward-compatible alias preserved for users importing the old name.
+FreeBootstrapperConfig = FreeConfig

--- a/lite_bootstrap/bootstrappers/litestar_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/litestar_bootstrapper.py
@@ -12,7 +12,7 @@ from lite_bootstrap.instruments.healthchecks_instrument import (
     HealthCheckTypedDict,
 )
 from lite_bootstrap.instruments.logging_instrument import LoggingConfig, LoggingInstrument
-from lite_bootstrap.instruments.opentelemetry_instrument import OpentelemetryConfig, OpenTelemetryInstrument
+from lite_bootstrap.instruments.opentelemetry_instrument import OpenTelemetryConfig, OpenTelemetryInstrument
 from lite_bootstrap.instruments.prometheus_instrument import (
     PrometheusConfig as PrometheusBootstrapperConfig,
 )
@@ -104,7 +104,7 @@ class LitestarConfig(
     CorsConfig,
     HealthChecksConfig,
     LoggingConfig,
-    OpentelemetryConfig,
+    OpenTelemetryConfig,
     PrometheusBootstrapperConfig,
     PyroscopeConfig,
     SentryConfig,

--- a/lite_bootstrap/instruments/opentelemetry_instrument.py
+++ b/lite_bootstrap/instruments/opentelemetry_instrument.py
@@ -39,7 +39,7 @@ class OpenTelemetryServiceFieldsConfig(BaseConfig):
 
 
 @dataclasses.dataclass(kw_only=True, frozen=True)
-class OpentelemetryConfig(OpenTelemetryServiceFieldsConfig):
+class OpenTelemetryConfig(OpenTelemetryServiceFieldsConfig):
     opentelemetry_container_name: str | None = dataclasses.field(
         default_factory=lambda: os.environ.get("HOSTNAME") or None
     )
@@ -78,7 +78,7 @@ if import_checker.is_opentelemetry_installed and import_checker.is_pyroscope_ins
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class OpenTelemetryInstrument(BaseInstrument[OpentelemetryConfig]):
+class OpenTelemetryInstrument(BaseInstrument[OpenTelemetryConfig]):
     not_ready_message = "opentelemetry_endpoint is empty and opentelemetry_log_traces is False"
     missing_dependency_message = "opentelemetry is not installed"
     _tracer_provider: "TracerProvider | None" = dataclasses.field(
@@ -153,3 +153,7 @@ class OpenTelemetryInstrument(BaseInstrument[OpentelemetryConfig]):
                 self._tracer_provider.shutdown()
             finally:
                 self._tracer_provider = None
+
+
+# Backward-compatible alias preserved for users importing the old (lowercase t) spelling.
+OpentelemetryConfig = OpenTelemetryConfig

--- a/tests/instruments/test_logging_instrument.py
+++ b/tests/instruments/test_logging_instrument.py
@@ -8,7 +8,7 @@ from opentelemetry.trace import get_tracer
 
 from lite_bootstrap.instruments.logging_factory import _MemoryLoggerFactoryConfig
 from lite_bootstrap.instruments.logging_instrument import LoggingConfig, LoggingInstrument, MemoryLoggerFactory
-from lite_bootstrap.instruments.opentelemetry_instrument import OpentelemetryConfig, OpenTelemetryInstrument
+from lite_bootstrap.instruments.opentelemetry_instrument import OpenTelemetryConfig, OpenTelemetryInstrument
 from tests.conftest import LoggingMock
 
 
@@ -51,7 +51,7 @@ def test_logging_instrument_tracer_injection(logging_mock: LoggingMock) -> None:
         )
     )
     opentelemetry_instrument = OpenTelemetryInstrument(
-        bootstrap_config=OpentelemetryConfig(
+        bootstrap_config=OpenTelemetryConfig(
             opentelemetry_log_traces=True,
         )
     )

--- a/tests/instruments/test_opentelemetry_instrument.py
+++ b/tests/instruments/test_opentelemetry_instrument.py
@@ -4,7 +4,7 @@ import pytest
 
 from lite_bootstrap.instruments.opentelemetry_instrument import (
     InstrumentorWithParams,
-    OpentelemetryConfig,
+    OpenTelemetryConfig,
     OpenTelemetryInstrument,
 )
 from tests.conftest import CustomInstrumentor
@@ -12,7 +12,7 @@ from tests.conftest import CustomInstrumentor
 
 def test_opentelemetry_instrument() -> None:
     opentelemetry_instrument = OpenTelemetryInstrument(
-        bootstrap_config=OpentelemetryConfig(
+        bootstrap_config=OpenTelemetryConfig(
             opentelemetry_instrumentors=[
                 InstrumentorWithParams(instrumentor=CustomInstrumentor(), additional_params={"key": "value"}),
                 CustomInstrumentor(),
@@ -28,7 +28,7 @@ def test_opentelemetry_instrument() -> None:
 
 def test_opentelemetry_instrument_empty_instruments() -> None:
     opentelemetry_instrument = OpenTelemetryInstrument(
-        bootstrap_config=OpentelemetryConfig(
+        bootstrap_config=OpenTelemetryConfig(
             opentelemetry_log_traces=True,
         )
     )
@@ -40,7 +40,7 @@ def test_opentelemetry_instrument_empty_instruments() -> None:
 
 def test_opentelemetry_instrument_teardown_shuts_down_tracer_provider() -> None:
     instrument = OpenTelemetryInstrument(
-        bootstrap_config=OpentelemetryConfig(opentelemetry_log_traces=True),
+        bootstrap_config=OpenTelemetryConfig(opentelemetry_log_traces=True),
     )
     instrument.bootstrap()
     tracer_provider = instrument._tracer_provider  # noqa: SLF001
@@ -55,7 +55,7 @@ def test_opentelemetry_instrument_teardown_shuts_down_tracer_provider() -> None:
 
 def test_opentelemetry_instrument_teardown_resets_tracer_provider_when_shutdown_raises() -> None:
     instrument = OpenTelemetryInstrument(
-        bootstrap_config=OpentelemetryConfig(opentelemetry_log_traces=True),
+        bootstrap_config=OpenTelemetryConfig(opentelemetry_log_traces=True),
     )
     instrument.bootstrap()
     tracer_provider = instrument._tracer_provider  # noqa: SLF001

--- a/tests/instruments/test_pyroscope_instrument.py
+++ b/tests/instruments/test_pyroscope_instrument.py
@@ -10,7 +10,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 import lite_bootstrap.instruments.opentelemetry_instrument as otel_module
-from lite_bootstrap import FreeBootstrapperConfig
+from lite_bootstrap import FreeConfig
 from lite_bootstrap.instruments.opentelemetry_instrument import OpenTelemetryInstrument
 from lite_bootstrap.instruments.pyroscope_instrument import PyroscopeConfig, PyroscopeInstrument
 
@@ -52,7 +52,7 @@ def test_pyroscope_instrument_bootstrap_and_teardown() -> None:
 
 
 def test_pyroscope_bootstrap_uses_opentelemetry_service_name() -> None:
-    config = FreeBootstrapperConfig(
+    config = FreeConfig(
         service_name="fallback",
         pyroscope_endpoint="http://pyroscope:4040",
         opentelemetry_service_name="otel-name",
@@ -78,7 +78,7 @@ def test_pyroscope_standalone_config_accepts_otel_fields() -> None:
 
 
 def test_pyroscope_bootstrap_merges_namespace_tag() -> None:
-    config = FreeBootstrapperConfig(
+    config = FreeConfig(
         service_name="svc",
         pyroscope_endpoint="http://pyroscope:4040",
         pyroscope_tags={"env": "prod"},
@@ -165,7 +165,7 @@ def test_pyroscope_span_processor_on_start_remote_parent() -> None:
 
 def test_pyroscope_otel_adds_span_processor_when_configured() -> None:
     """OTel instrument adds PyroscopeSpanProcessor when pyroscope_endpoint is set."""
-    config = FreeBootstrapperConfig(
+    config = FreeConfig(
         service_name="test-svc",
         opentelemetry_log_traces=True,
         pyroscope_endpoint="http://pyroscope:4040",

--- a/tests/test_free_bootstrap.py
+++ b/tests/test_free_bootstrap.py
@@ -6,7 +6,7 @@ from structlog.testing import capture_logs
 
 from lite_bootstrap import (
     FreeBootstrapper,
-    FreeBootstrapperConfig,
+    FreeConfig,
     InstrumentNotReadyWarning,
     TeardownError,
 )
@@ -17,8 +17,8 @@ logger = structlog.getLogger(__name__)
 
 
 @pytest.fixture
-def free_bootstrapper_config() -> FreeBootstrapperConfig:
-    return FreeBootstrapperConfig(
+def free_bootstrapper_config() -> FreeConfig:
+    return FreeConfig(
         service_debug=False,
         opentelemetry_instrumentors=[CustomInstrumentor()],
         opentelemetry_log_traces=True,
@@ -27,7 +27,7 @@ def free_bootstrapper_config() -> FreeBootstrapperConfig:
     )
 
 
-def test_free_bootstrap(free_bootstrapper_config: FreeBootstrapperConfig) -> None:
+def test_free_bootstrap(free_bootstrapper_config: FreeConfig) -> None:
     bootstrapper = FreeBootstrapper(bootstrap_config=free_bootstrapper_config)
     bootstrapper.bootstrap()
     try:
@@ -39,7 +39,7 @@ def test_free_bootstrap(free_bootstrapper_config: FreeBootstrapperConfig) -> Non
 def test_free_bootstrap_logging_disabled() -> None:
     with pytest.warns(InstrumentNotReadyWarning) as records:
         FreeBootstrapper(
-            bootstrap_config=FreeBootstrapperConfig(
+            bootstrap_config=FreeConfig(
                 logging_enabled=False,
                 opentelemetry_instrumentors=[CustomInstrumentor()],
                 opentelemetry_log_traces=True,
@@ -53,7 +53,7 @@ def test_free_bootstrap_logging_disabled() -> None:
     assert "PyroscopeInstrument is not ready: pyroscope_endpoint is empty" in messages
 
 
-def test_teardown_error_isolation(free_bootstrapper_config: FreeBootstrapperConfig) -> None:
+def test_teardown_error_isolation(free_bootstrapper_config: FreeConfig) -> None:
     bootstrapper = FreeBootstrapper(bootstrap_config=free_bootstrapper_config)
     bootstrapper.bootstrap()
 
@@ -73,7 +73,7 @@ def test_teardown_error_isolation(free_bootstrapper_config: FreeBootstrapperConf
     assert excinfo.value.errors == [("MagicMock", excinfo.value.__cause__)]
 
 
-def test_teardown_error_aggregates_all_failures(free_bootstrapper_config: FreeBootstrapperConfig) -> None:
+def test_teardown_error_aggregates_all_failures(free_bootstrapper_config: FreeConfig) -> None:
     bootstrapper = FreeBootstrapper(bootstrap_config=free_bootstrapper_config)
     bootstrapper.bootstrap()
 
@@ -104,13 +104,13 @@ def test_teardown_error_aggregates_all_failures(free_bootstrapper_config: FreeBo
     ],
 )
 def test_free_bootstrapper_with_missing_instrument_dependency(
-    free_bootstrapper_config: FreeBootstrapperConfig, package_name: str
+    free_bootstrapper_config: FreeConfig, package_name: str
 ) -> None:
     with emulate_package_missing(package_name), pytest.warns(UserWarning, match=package_name):
         FreeBootstrapper(bootstrap_config=free_bootstrapper_config)
 
 
-def test_teardown_is_idempotent(free_bootstrapper_config: FreeBootstrapperConfig) -> None:
+def test_teardown_is_idempotent(free_bootstrapper_config: FreeConfig) -> None:
     bootstrapper = FreeBootstrapper(bootstrap_config=free_bootstrapper_config)
     bootstrapper.bootstrap()
 


### PR DESCRIPTION
## Summary
The final PR of the deferred-refactors sequence. Two API-surface renames with silent backward-compatibility aliases:

- **`OpentelemetryConfig` → `OpenTelemetryConfig`** — matches the conventional OpenTelemetry capitalization and the `OpenTelemetryServiceFieldsConfig` mixin from PR6. Module-level alias preserves existing imports. Not exported from `__init__.py` (wasn't before).
- **`FreeBootstrapperConfig` → `FreeConfig`** — matches the sibling configs (`FastAPIConfig`, `LitestarConfig`, `FastStreamConfig` — none carry the `Bootstrapper` infix). Module-level alias plus `FreeBootstrapperConfig` re-export in `__init__.py` preserves existing public imports.

Internal references and tests updated to the new canonical names. Aliases are simple class assignments — same class object, so `isinstance(x, OldName)` and `isinstance(x, NewName)` are interchangeable. Old pickles continue to unpickle via the alias.

10 files modified, no behavior change. 129/129 tests pass.

Closes LOW-7 from an internal audit. Also closes the bonus Otel capitalization item surfaced during PR6's code review.

## Test plan
- [x] `just test` — 129/129.
- [x] `just lint` — clean.
- [x] Aliases verified working (`isinstance(x, OldName) is isinstance(x, NewName)` for both renames).
- [x] Sanity grep confirms old names appear ONLY in alias contexts (4 matches: 2 alias lines + 2 in `__init__.py`).
- [x] Reviewer: confirm the aliases are simple class assignments (not subclasses), so isinstance behavior is fully preserved.

## Why silent aliases
Locked decision in the sequencing spec: silent aliases (no warn-on-access). The library is small, and warn-on-access is overkill for two targeted renames where the new names are uncontroversially better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)