### PR TITLE
fix: make BaseBootstrapper.bootstrap() idempotent

### DIFF
--- a/lite_bootstrap/bootstrappers/base.py
+++ b/lite_bootstrap/bootstrappers/base.py
@@ -74,6 +74,8 @@ class BaseBootstrapper(abc.ABC, typing.Generic[ApplicationT]):
     def is_ready(self) -> bool: ...
 
     def bootstrap(self) -> ApplicationT:
+        if self.is_bootstrapped:
+            return self._prepare_application()
         self.is_bootstrapped = True
         for one_instrument in self.instruments:
             one_instrument.bootstrap()

--- a/tests/test_free_bootstrap.py
+++ b/tests/test_free_bootstrap.py
@@ -124,3 +124,18 @@ def test_teardown_is_idempotent(free_bootstrapper_config: FreeConfig) -> None:
     first.teardown.assert_called_once()
     second.teardown.assert_called_once()
     assert not bootstrapper.is_bootstrapped
+
+
+def test_bootstrap_is_idempotent(free_bootstrapper_config: FreeConfig) -> None:
+    bootstrapper = FreeBootstrapper(bootstrap_config=free_bootstrapper_config)
+
+    first = MagicMock()
+    second = MagicMock()
+    bootstrapper.instruments = [first, second]
+
+    bootstrapper.bootstrap()
+    bootstrapper.bootstrap()
+
+    first.bootstrap.assert_called_once()
+    second.bootstrap.assert_called_once()
+    assert bootstrapper.is_bootstrapped


### PR DESCRIPTION
## Summary

`BaseBootstrapper.teardown()` short-circuits when `is_bootstrapped` is False, but `bootstrap()` had no symmetric guard. Calling `bootstrapper.bootstrap()` twice would re-invoke every instrument's `bootstrap`, with user-visible side effects:

- The FastMCP access-log middleware would mount twice → every MCP request gets logged twice.
- Re-registering a Prometheus `/metrics` route via `application.custom_route(...)` raises.
- The FastAPI lifespan composition runs twice → `_TeardownProvider` registered twice on FastMCP.
- structlog reconfiguration leaks duplicate stream handlers on the root logger.

Add the symmetric guard at the top of `bootstrap()`: when already bootstrapped, return the prepared application without re-running the instruments.

## Test plan

- [x] `just test` — full suite (149 tests, +1 new) passes
- [x] `just lint` — clean
- [x] New test `test_bootstrap_is_idempotent` mirrors the shape of the existing `test_teardown_is_idempotent` — wires two `MagicMock()` instruments onto the bootstrapper, calls `bootstrap()` twice, asserts each instrument's `bootstrap` was called exactly once and `is_bootstrapped` is True

Flagged as a follow-up during review of #105 (FastMCP bootstrapper) — the MCP access middleware made the double-mount symptom user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)