### PR TITLE
ci: bump action pins to match modern-di

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
@@ -35,9 +35,9 @@ jobs:
           - "3.13"
           - "3.14"
     steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: astral-sh/setup-uv@v8.2.0
       - run: just publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary

Brings `ci.yml` and `publish.yml` action versions in line with the sibling [`modern-di`](https://github.com/modern-python/modern-di) project. The docs workflow added in #112 already uses these versions; this PR catches the older workflows up so the whole repo shares one pin set.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `extractions/setup-just` | `@v2` | `@v4` |
| `astral-sh/setup-uv` | `@v3` | `@v8.2.0` |

The `with: enable-cache: true, cache-dependency-glob: "**/pyproject.toml"` block on `setup-uv` in `ci.yml` is preserved (modern-di also keeps it on `@v8.2.0`).

## Scope

- `.github/workflows/ci.yml` — 6 line changes (both `lint` and `pytest` jobs)
- `.github/workflows/publish.yml` — 3 line changes

## Out of scope

- `codecov/codecov-action@v4.0.1` — modern-di dropped codecov rather than bumping it, so there is no clear target version to mirror. Leaving as-is. Worth a separate decision (bump vs. drop).
- Splitting `ci.yml` into a reusable `_checks.yml` workflow like modern-di did. That's a structural refactor, not a version bump — separate PR if wanted.

## Test plan

- [ ] PR's CI run completes green on all matrix Python versions (3.10–3.14) with the new action pins.
- [ ] Local `just lint-ci` and `just test` already passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)