### PR TITLE
ci: split ci.yml into reusable _checks.yml

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -1,0 +1,38 @@
+name: checks
+on:
+  workflow_call: {}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+      - run: uv python install 3.10
+      - run: just install lint-ci
+
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+      - run: uv python install ${{ matrix.python-version }}
+      - run: just install
+      - run: just test . --cov=. --cov-report xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: main
-
 on:
   push:
     branches:
@@ -11,36 +10,5 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v4
-      - uses: astral-sh/setup-uv@v8.2.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: "**/pyproject.toml"
-      - run: uv python install 3.10
-      - run: just install lint-ci
-
-  pytest:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "3.14"
-    steps:
-      - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v4
-      - uses: astral-sh/setup-uv@v8.2.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: "**/pyproject.toml"
-      - run: uv python install ${{ matrix.python-version }}
-      - run: just install
-      - run: just test . --cov=. --cov-report xml
+  checks:
+    uses: ./.github/workflows/_checks.yml


### PR DESCRIPTION
## Summary

Structural mirror of [`modern-di`](https://github.com/modern-python/modern-di)'s CI shape:

- `ci.yml` becomes a thin **trigger wrapper** (push to `main`, `pull_request`, concurrency group) that delegates to `_checks.yml`.
- `_checks.yml` is a **reusable workflow** (`on: workflow_call`) holding the `lint` and `pytest` jobs.

Both files are now **byte-identical** to their modern-di counterparts:

```bash
diff .github/workflows/ci.yml      ../modern-di/.github/workflows/ci.yml      # empty
diff .github/workflows/_checks.yml ../modern-di/.github/workflows/_checks.yml # empty
```

## Why

- Sets the shape up to add more callers later (nightly schedule, manual dispatch, dependent workflows) without duplicating the job definitions.
- Aligns both repos in the modern-python org on one CI shape — easier to keep them in sync going forward.

## Behaviour change

None. Same triggers, same concurrency group, same jobs, same steps, same matrix. The split is purely a `workflow_call` indirection.

## Test plan

- [ ] CI green on this PR — both the `lint` and `pytest` (5-Python matrix) reusable jobs should run via the `checks` caller in `ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)