### PR TITLE
ci: bump security-audit.yml action pins

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -13,8 +13,8 @@ jobs:
   pip-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"


### PR DESCRIPTION
## Summary

`security-audit.yml` was added after PR #113 and was missed by that bump sweep. This catches it up: `actions/checkout@v4` → `@v6` and `astral-sh/setup-uv@v3` → `@v8.2.0`. No `setup-just` in this workflow, so only two pins change.

## Test plan

- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)