### PR TITLE
ci: add weekly scheduled dependency check

### DIFF
--- a/.github/scripts/report-scheduled-failure.sh
+++ b/.github/scripts/report-scheduled-failure.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LABEL="scheduled-failure"
+TITLE="Scheduled dependency check failed"
+
+# Ensure the label exists. --force makes this idempotent: creates if absent,
+# updates color/description without error if present.
+gh label create "$LABEL" \
+  --color "FBCA04" \
+  --description "Weekly dependency check failures" \
+  --force
+
+# Find an open issue with our label, if any. --jq '.[0].number // empty'
+# yields the first number or an empty string when there are no matches.
+existing=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number // empty')
+
+if [ -z "$existing" ]; then
+  body=$(printf '%s\n\n%s\n\n%s\n\n%s' \
+    "The weekly scheduled dependency check failed." \
+    "First failing run: ${RUN_URL}" \
+    "Likely cause: a transitive dev or lint dependency (ruff, ty, eof-fixer, pytest, typing-extensions) released a breaking change. Reproduce locally with \`just install\` then \`just lint\` and \`just test\`." \
+    "Close this issue once fixed. The next scheduled failure will open a fresh issue.")
+  gh issue create --title "$TITLE" --label "$LABEL" --body "$body"
+else
+  gh issue comment "$existing" --body "Failed again: ${RUN_URL}"
+fi

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,28 @@
+name: scheduled-dep-check
+on:
+  schedule:
+    - cron: "0 6 * * 1"        # Mondays 06:00 UTC
+  workflow_dispatch: {}
+
+concurrency:
+  group: scheduled-dep-check
+  cancel-in-progress: false
+
+jobs:
+  checks:
+    uses: ./.github/workflows/_checks.yml
+
+  report-failure:
+    needs: checks
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Open or update tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash .github/scripts/report-scheduled-failure.sh


### PR DESCRIPTION
Adds a weekly scheduled dependency check, mirroring the pattern already in `modern-di` and `faststream-outbox`.

**What it does**
- `.github/workflows/scheduled.yml` — runs the repo's existing `_checks.yml` reusable workflow on a `Mon 06:00 UTC` cron (and on manual `workflow_dispatch`).
- On a **scheduled** failure, a `report-failure` job opens (or comments on) a single `scheduled-failure` tracking issue via `.github/scripts/report-scheduled-failure.sh`.

**Why**
Catches dependency drift — a transitive dev/lint dep (ruff, ty, eof-fixer, pytest, typing-extensions) shipping a breaking change — on a schedule, before it surprises a normal CI run.

No code or existing-CI changes; the scheduled job calls this repo's own `_checks.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)