### PR TITLE
fix(fastapi): handle FastAPI 0.137 _IncludedRouter route type

### DIFF
--- a/lite_bootstrap/helpers/fastapi_helpers.py
+++ b/lite_bootstrap/helpers/fastapi_helpers.py
@@ -1,5 +1,4 @@
 import pathlib
-import typing
 import warnings
 
 from lite_bootstrap import import_checker
@@ -47,10 +46,13 @@ def enable_offline_docs(
     redoc_url: str = app.redoc_url or "/redoc"
     swagger_ui_oauth2_redirect_url: str = app.swagger_ui_oauth2_redirect_url or "/docs/oauth2-redirect"
 
+    replaced_urls = (docs_url, redoc_url, swagger_ui_oauth2_redirect_url)
     app.router.routes = [
         route
         for route in app.router.routes
-        if typing.cast(Route, route).path not in (docs_url, redoc_url, swagger_ui_oauth2_redirect_url)
+        # Only the auto-generated docs endpoints are plain ``Route``s with a ``path``; other route
+        # types (e.g. FastAPI's ``_IncludedRouter``) lack ``.path`` and must be left untouched.
+        if not (isinstance(route, Route) and route.path in replaced_urls)
     ]
 
     static_dir_path = pathlib.Path(__file__).parent.parent / "static/fastapi_docs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,11 @@ free-all = [
     "lite-bootstrap[sentry,otl,logging,pyroscope]",
 ]
 fastapi = [
-    "fastapi",
+    # FastAPI 0.137 introduced the internal `_IncludedRouter` route type, which
+    # prometheus-fastapi-instrumentator (<=8.0.0) does not handle (it reads `route.path`
+    # unconditionally and raises AttributeError). Cap until a fixed instrumentator ships.
+    # Upstream issue: https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370
+    "fastapi<0.137",
 ]
 fastapi-sentry = [
     "lite-bootstrap[fastapi,sentry]",


### PR DESCRIPTION
## Problem

CI on `main` went red across all Python versions. `just install` runs `uv lock --upgrade`, which pulled **FastAPI 0.137.0**. That release introduced an internal `_IncludedRouter` route type (a `BaseRoute` subclass with **no `.path`**) into `app.router.routes`, and two places read `route.path` unconditionally:

1. **Our code** — `lite_bootstrap/helpers/fastapi_helpers.py` did `typing.cast(Route, route).path`. The cast is a runtime no-op, so it raised `AttributeError: '_IncludedRouter' object has no attribute 'path'`.
2. **`prometheus-fastapi-instrumentator` 8.0.0** (latest, third-party) — same unguarded `route.path` access. No upstream fix released yet.

## Changes

- **`fastapi_helpers.py`** — filter the offline-docs routes by matching only real `Route` instances (`isinstance(route, Route) and route.path in replaced_urls`), leaving `_IncludedRouter` and other route types untouched. Correct on both old and new FastAPI, so nothing to revert when the cap lifts. Dropped the now-unused `import typing`.
- **`pyproject.toml`** — added `fastapi<0.137` to the base `fastapi` extra (the single source every other `fastapi-*` extra composes from), so the whole FastAPI surface resolves to a version tested end-to-end and there's no version skew between extras. Comment links the upstream issue.

The cap is temporary, tied to upstream **trallnag/prometheus-fastapi-instrumentator#370**; lift it once a fixed instrumentator ships.

## Verification

- `just test` → **194 passed, 100% coverage**
- `just lint-ci` → eof-fixer, ruff format, ruff check, ty all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)