### PR TITLE
docs: release notes for 1.1.1

### DIFF
--- a/planning/releases/1.1.1.md
+++ b/planning/releases/1.1.1.md
@@ -1,0 +1,21 @@
+# lite-bootstrap 1.1.1 — FastAPI 0.137 compatibility
+
+**1.1.1 is a patch release. No public-API or behavior changes.** It restores compatibility with FastAPI 0.137 and pins a transitive incompatibility, nothing more.
+
+## Bug fixes
+
+- **Offline docs no longer crash on FastAPI 0.137's `_IncludedRouter`** (PR [#122](https://github.com/modern-python/lite-bootstrap/pull/122)). FastAPI 0.137.0 added the internal `_IncludedRouter` route type (a `BaseRoute` subclass with no `.path`) to `app.router.routes`. `enable_offline_docs` filtered routes via an unchecked `typing.cast(Route, route).path`, which raised `AttributeError: '_IncludedRouter' object has no attribute 'path'` whenever a router was included (e.g. by the health-checks instrument). The filter now matches only real `Route` instances (`isinstance(route, Route) and route.path in …`), leaving `_IncludedRouter` and other route types untouched. Correct on both old and new FastAPI.
+
+## Dependency constraints
+
+- **`fastapi<0.137` cap on the `fastapi` extra (temporary).** `prometheus-fastapi-instrumentator` (≤ 8.0.0) has the same unguarded `route.path` access and is not yet fixed upstream, so any lite-bootstrap install that pulls FastAPI 0.137 would break metrics. The cap lives on the base `fastapi` extra — the single declaration every other `fastapi-*` extra composes from — so the whole FastAPI surface resolves to a version tested end-to-end with no skew between extras. Lift the cap once a fixed instrumentator ships.
+  - Upstream issue: [trallnag/prometheus-fastapi-instrumentator#370](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370)
+
+## Backwards compatibility
+
+Fully backward compatible with 1.1.0. No public API changed; the FastAPI fix is purely defensive. The only observable difference is the new `fastapi<0.137` resolution ceiling, which holds installs at a known-good FastAPI until the upstream metrics fix lands.
+
+## References
+
+- PR: [#122](https://github.com/modern-python/lite-bootstrap/pull/122)
+- Upstream issue: [trallnag/prometheus-fastapi-instrumentator#370](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370)


### PR DESCRIPTION
Release notes for **1.1.1**, a patch release.

Since 1.1.0 the only user-facing change is PR #122: FastAPI 0.137 `_IncludedRouter` compatibility fix in the offline-docs helper, plus a temporary `fastapi<0.137` cap on the `fastapi` extra (upstream blocker: trallnag/prometheus-fastapi-instrumentator#370). Everything else on main since 1.1.0 is docs/CI/planning.

Follows the established convention: `planning/releases/X.Y.Z.md`. Once merged, tagging `1.1.1` on the merge commit and publishing the GitHub Release triggers `publish.yml` → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)