### PR TITLE
ci: deploy docs via GitHub Actions Pages (drop gh-pages branch)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,20 +9,32 @@ on:
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
-concurrency:
-  group: docs-deploy
-  cancel-in-progress: true
-
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - uses: extractions/setup-just@v4
       - uses: astral-sh/setup-uv@v8.2.0
-      - run: just docs-deploy
+      - run: just docs-build
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/Justfile
+++ b/Justfile
@@ -28,11 +28,6 @@ publish:
     uv build
     uv publish --token $PYPI_TOKEN
 
-# Force-pushes built site to gh-pages; CI runs this on push to main.
-# Manual invocation from a stale checkout will roll the live site back.
-docs-deploy:
-    uvx --with-requirements docs/requirements.txt mkdocs gh-deploy --force
-
 # Strict local docs build (no deploy). Mirrors CI's link/strict checks.
 docs-build:
     uvx --with-requirements docs/requirements.txt mkdocs build --strict


### PR DESCRIPTION
Migrates docs deploy to the org's GitHub-managed Pages flow (build artifact + actions/deploy-pages); removes the obsolete docs-deploy Justfile recipe. Pages source flip to GitHub Actions + gh-pages branch deletion happen as a post-merge cutover. Part of a 6-repo rollout.