### PR TITLE
chore: lift the fastapi<0.137 cap

### DIFF
--- a/planning/releases/1.2.1.md
+++ b/planning/releases/1.2.1.md
@@ -1,0 +1,21 @@
+# lite-bootstrap 1.2.1 — lift the FastAPI 0.137 cap
+
+**1.2.1 is a patch release. No public-API or behavior changes.** It removes the temporary `fastapi<0.137` ceiling introduced in 1.1.1, now that the upstream `prometheus-fastapi-instrumentator` fix has shipped.
+
+## Dependency constraints
+
+- **`fastapi<0.137` cap removed** from the `fastapi` extra (the single declaration every `fastapi-*` extra composes from). FastAPI 0.137 and 0.138 now resolve.
+- **`prometheus-fastapi-instrumentator` floor raised** on the `fastapi-metrics` extra: `>=6.1` → `>=8.0.1`. The crash that motivated the cap required FastAPI ≥0.137 *and* instrumentator ≤8.0.0, so lifting the FastAPI ceiling is paired with a floor that guarantees the fixed instrumentator wherever metrics are installed.
+
+The original cap was added in 1.1.1 because `prometheus-fastapi-instrumentator` read `route.path` unconditionally and crashed on FastAPI 0.137's internal `_IncludedRouter` route type. That is fixed upstream in instrumentator [v8.0.1](https://github.com/trallnag/prometheus-fastapi-instrumentator/releases/tag/v8.0.1) (issue [#370](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370), closed 2026-06-22). lite-bootstrap's own offline-docs guard (the `isinstance(route, Route)` filter shipped in 1.1.1) remains in place.
+
+Verified end-to-end against FastAPI 0.138.0 + prometheus-fastapi-instrumentator 8.0.2: full suite green at 100% coverage, including the offline-docs and metrics paths that previously crashed.
+
+## Backwards compatibility
+
+Fully backward compatible with 1.2.0. No public API or behavior changed; this is purely a loosening of resolution constraints. Installs that were held at FastAPI ≤0.136 by the cap will now resolve forward to current FastAPI.
+
+## References
+
+- Upstream fix: [prometheus-fastapi-instrumentator v8.0.1](https://github.com/trallnag/prometheus-fastapi-instrumentator/releases/tag/v8.0.1), issue [#370](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370)
+- Original cap: 1.1.1 (PR [#122](https://github.com/modern-python/lite-bootstrap/pull/122))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,11 +51,7 @@ free-all = [
     "lite-bootstrap[sentry,otl,logging,pyroscope]",
 ]
 fastapi = [
-    # FastAPI 0.137 introduced the internal `_IncludedRouter` route type, which
-    # prometheus-fastapi-instrumentator (<=8.0.0) does not handle (it reads `route.path`
-    # unconditionally and raises AttributeError). Cap until a fixed instrumentator ships.
-    # Upstream issue: https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370
-    "fastapi<0.137",
+    "fastapi",
 ]
 fastapi-sentry = [
     "lite-bootstrap[fastapi,sentry]",
@@ -69,7 +65,9 @@ fastapi-logging = [
 ]
 fastapi-metrics = [
     "lite-bootstrap[fastapi]",
-    "prometheus-fastapi-instrumentator>=6.1",
+    # >=8.0.1 carries the _IncludedRouter fix required for FastAPI >=0.137
+    # (trallnag/prometheus-fastapi-instrumentator#370).
+    "prometheus-fastapi-instrumentator>=8.0.1",
 ]
 fastapi-all = [
     "lite-bootstrap[fastapi-sentry,fastapi-otl,fastapi-logging,fastapi-metrics,pyroscope]",


### PR DESCRIPTION
## What

Lifts the temporary `fastapi<0.137` cap introduced in 1.1.1, now that the upstream fix has shipped.

- Remove `fastapi<0.137` from the `fastapi` extra (the base every `fastapi-*` extra composes from).
- Raise the `fastapi-metrics` floor: `prometheus-fastapi-instrumentator>=6.1` → `>=8.0.1`.

## Why

The cap existed solely because `prometheus-fastapi-instrumentator` (≤8.0.0) read `route.path` unconditionally and crashed on FastAPI 0.137's internal `_IncludedRouter`. That's fixed upstream in instrumentator [v8.0.1](https://github.com/trallnag/prometheus-fastapi-instrumentator/releases/tag/v8.0.1) (issue [#370](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370), closed 2026-06-22). The crash needed FastAPI ≥0.137 **and** instrumentator ≤8.0.0, so the FastAPI uncap is paired with an instrumentator floor that guarantees the fix wherever metrics are installed.

## Verification

Re-resolved and ran against the previously-forbidden combination **FastAPI 0.138.0 + prometheus-fastapi-instrumentator 8.0.2**:

- FastAPI suite green (offline-docs + metrics — the exact `_IncludedRouter` crash surface)
- Full suite: 201 passed, 100% coverage
- `just lint` clean (`ruff` + `ty`)

lite-bootstrap's own offline-docs `isinstance(route, Route)` guard (from 1.1.1) stays in place.

## Release

Backward compatible with 1.2.0 — purely a resolution-constraint loosening. Release notes drafted as `planning/releases/1.2.1.md`; intended as a **1.2.1** patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)