### PR TITLE
docs: lead README with the observability value proposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
 
-`lite-bootstrap` helps you bootstrap production-ready Python microservices with all the necessary instruments already set up.
+`lite-bootstrap` wires production observability — OpenTelemetry, Prometheus, Sentry, and structlog — into FastAPI, Litestar, and FastStream services in a few lines, with no boilerplate.
 
 With `lite-bootstrap`, you receive an application with lightweight built-in support for:
 - `sentry`


### PR DESCRIPTION
Opens the README with what lite-bootstrap concretely does — wires production observability (OpenTelemetry, Prometheus, Sentry, structlog) into FastAPI, Litestar, and FastStream services in a few lines — instead of the generic "bootstrap production-ready microservices" line. The instrument list and details follow unchanged. Part of the modern-python positioning work.