### PR TITLE
docs: source download badge from pepy.tech to stop pypistats rate-limit errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/lite-bootstrap.svg)](https://pypi.org/project/lite-bootstrap/)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/lite-bootstrap.svg)](https://pypi.org/project/lite-bootstrap/)
-[![Downloads](https://img.shields.io/pypi/dm/lite-bootstrap.svg)](https://pypistats.org/packages/lite-bootstrap)
+[![Downloads](https://static.pepy.tech/badge/lite-bootstrap/month)](https://pepy.tech/projects/lite-bootstrap)
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen.svg)](https://github.com/modern-python/lite-bootstrap/actions/workflows/ci.yml)
 [![CI](https://github.com/modern-python/lite-bootstrap/actions/workflows/ci.yml/badge.svg)](https://github.com/modern-python/lite-bootstrap/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/modern-python/lite-bootstrap.svg)](https://github.com/modern-python/lite-bootstrap/blob/main/LICENSE)


### PR DESCRIPTION
## Problem

The download badge used `img.shields.io/pypi/dm/<pkg>`, which shields.io sources from **pypistats.org**. pypistats rate-limits **by IP**, so the badge intermittently rendered **"rate limited by upstream service"** ([badges/shields#11620](https://github.com/badges/shields/issues/11620)).

## Change

- Image: `img.shields.io/pypi/dm/<pkg>.svg` -> `static.pepy.tech/badge/<pkg>/month`
- Link: `pypistats.org/packages/<pkg>` -> `pepy.tech/projects/<pkg>`

pepy serves statically cached SVGs from a different upstream. Metric stays **monthly downloads**. Mirrors the same fix already merged in `modern-di` (#250).

## Verification

- `static.pepy.tech/badge/<pkg>/month` returns HTTP 200 and renders a count.
- Docs-only change; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)