### PR TITLE
docs: fix broken home-page list, dead links, and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 `lite-bootstrap` wires production observability — OpenTelemetry, Prometheus, Sentry, and structlog — into FastAPI, Litestar, and FastStream services in a few lines, with no boilerplate.
 
 With `lite-bootstrap`, you receive an application with lightweight built-in support for:
+
 - `sentry`
 - `prometheus`
 - `opentelemetry`

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ Welcome to the `lite-bootstrap` documentation!
 `lite-bootstrap` assists you in creating applications with all the necessary instruments already set up.
 
 With `lite-bootstrap`, you receive an application with lightweight built-in support for:
+
 - `sentry`
 - `prometheus`
 - `opentelemetry`
@@ -16,9 +17,9 @@ With `lite-bootstrap`, you receive an application with lightweight built-in supp
 
 Those instruments can be bootstrapped for:
 
-- [LiteStar](integrations/litestar)
-- [FastStream](integrations/faststream)
-- [FastAPI](integrations/fastapi)
-- [FastMCP](integrations/fastmcp)
-- [services and scripts without frameworks](integrations/free)
+- [LiteStar](integrations/litestar.md)
+- [FastStream](integrations/faststream.md)
+- [FastAPI](integrations/fastapi.md)
+- [FastMCP](integrations/fastmcp.md)
+- [services and scripts without frameworks](integrations/free.md)
 ---

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -1,4 +1,4 @@
-# Usage with `Fastapi`
+# Usage with `FastAPI`
 
 *Another example of usage with FastAPI - [fastapi-sqlalchemy-template](https://github.com/modern-python/fastapi-sqlalchemy-template)*
 
@@ -22,9 +22,9 @@
       poetry add lite-bootstrap[fastapi-all]
       ```
 
-Read more about available extras [here](../../../introduction/installation):
+Read more about available extras [here](../introduction/installation.md).
 
-## 2. Define bootstrapper config and build you application:
+## 2. Define bootstrapper config and build your application:
 
 ```python
 from lite_bootstrap import FastAPIConfig, FastAPIBootstrapper
@@ -45,4 +45,4 @@ bootstrapper = FastAPIBootstrapper(bootstrapper_config)
 application = bootstrapper.bootstrap()
 ```
 
-Read more about available configuration options [here](../../../introduction/configuration):
+Read more about available configuration options [here](../introduction/configuration.md).

--- a/docs/integrations/fastmcp.md
+++ b/docs/integrations/fastmcp.md
@@ -20,7 +20,7 @@
       poetry add lite-bootstrap[fastmcp-all]
       ```
 
-Read more about available extras [here](../../../introduction/installation):
+Read more about available extras [here](../introduction/installation.md).
 
 ## 2. Define bootstrapper config and build your application:
 
@@ -54,4 +54,4 @@ Teardown is wired through FastMCP's provider lifecycle — `bootstrapper.teardow
 runs automatically when the FastMCP server's ASGI lifespan shuts down (i.e. when
 the application that serves `application.http_app()` shuts down).
 
-Read more about available configuration options [here](../../../introduction/configuration):
+Read more about available configuration options [here](../introduction/configuration.md).

--- a/docs/integrations/faststream.md
+++ b/docs/integrations/faststream.md
@@ -20,9 +20,9 @@
       poetry add lite-bootstrap[faststream-all]
       ```
 
-Read more about available extras [here](../../../introduction/installation):
+Read more about available extras [here](../introduction/installation.md).
 
-## 2. Define bootstrapper config and build you application:
+## 2. Define bootstrapper config and build your application:
 
 ```python
 from lite_bootstrap import FastStreamConfig, FastStreamBootstrapper
@@ -50,4 +50,4 @@ bootstrapper = FastStreamBootstrapper(bootstrapper_config)
 application = bootstrapper.bootstrap()
 ```
 
-Read more about available configuration options [here](../../../introduction/configuration):
+Read more about available configuration options [here](../introduction/configuration.md).

--- a/docs/integrations/free.md
+++ b/docs/integrations/free.md
@@ -20,9 +20,9 @@
       poetry add lite-bootstrap[free-all]
       ```
 
-Read more about available extras [here](../../../introduction/installation):
+Read more about available extras [here](../introduction/installation.md).
 
-## 2. Define bootstrapper config and build you application:
+## 2. Define bootstrapper config and build your application:
 
 ```python
 from lite_bootstrap import FreeBootstrapperConfig, FreeBootstrapper
@@ -36,4 +36,4 @@ bootstrapper = FreeBootstrapper(bootstrapper_config)
 bootstrapper.bootstrap()
 ```
 
-Read more about available configuration options [here](../../../introduction/configuration):
+Read more about available configuration options [here](../introduction/configuration.md).

--- a/docs/integrations/litestar.md
+++ b/docs/integrations/litestar.md
@@ -22,9 +22,9 @@
       poetry add lite-bootstrap[litestar-all]
       ```
 
-Read more about available extras [here](../../../introduction/installation):
+Read more about available extras [here](../introduction/installation.md).
 
-## 2. Define bootstrapper config and build you application:
+## 2. Define bootstrapper config and build your application:
 
 ```python
 from lite_bootstrap import LitestarConfig, LitestarBootstrapper
@@ -45,7 +45,7 @@ bootstrapper = LitestarBootstrapper(bootstrapper_config)
 application = bootstrapper.bootstrap()
 ```
 
-Read more about available configuration options [here](../../../introduction/configuration):
+Read more about available configuration options [here](../introduction/configuration.md).
 
 ## Logging
 

--- a/docs/introduction/configuration.md
+++ b/docs/introduction/configuration.md
@@ -40,6 +40,7 @@ Prometheus's integration for Litestar requires `prometheus_client` package.
 
 Additional parameters for Litestar integration:
 
+- `prometheus_group_path` - defaults to `True` so the `path` metric label uses the route template (`/users/{id}`) instead of the raw URL, bounding metric cardinality. Set to `False` to record raw paths.
 - `prometheus_additional_params` - passed to `litestar.plugins.prometheus.PrometheusConfig`.
 
 ### Prometheus FastStream

--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -19,7 +19,7 @@ You can choose required framework and instruments using this table:
 * not used - means that the instrument is not implemented in the integration.
 * no extra - means that the instrument requires no additional dependencies.
 
-## Install `lite-bootstrap` using your favorite tool with choosen extras
+## Install `lite-bootstrap` using your favorite tool with chosen extras
 
 For example, if you want to bootstrap litestar with structlog and opentelemetry instruments:
 


### PR DESCRIPTION
## Summary

Audit and fix of the docs site (https://lite-bootstrap.modern-python.org/) triggered by the broken list on the home page.

- **Home-page broken list (the reported bug):** the "built-in support for:" list rendered as one run-together paragraph because python-markdown requires a blank line before a list. Added it. (`README.md`'s identical list only looked fine because GitHub's markdown is more lenient; mirrored the fix there for parity.)
- **Dead / fragile links:** every integration page's "Read more about extras/configuration" links pointed to `../../../introduction/...` — wrong depth (two extra `../`, clamped at site root), missing `.md`, dangling trailing colon. They only worked via a host redirect. Repointed to `../introduction/installation.md` / `../introduction/configuration.md`. Also fixed the home-page integration links to use `.md` targets.
- **Typos:** `build you application` -> `build your application` (4 pages), `choosen extras` -> `chosen extras`, `` `Fastapi` `` -> `` `FastAPI` `` heading.
- **Incompleteness:** documented the missing `prometheus_group_path` field in the Prometheus/Litestar config reference.

## Verification

- `uv run mkdocs build --strict` passes with no link/render warnings.
- Confirmed the built `site/index.html` now emits a real `<ul>` for the intro list.
- Extras matrix and every referenced config field were checked against `pyproject.toml` and the source — all accurate; no code changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)