### PR TITLE
docs: drop stray horizontal rule and tidy README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ With `lite-bootstrap`, you receive an application with lightweight built-in supp
 
 Those instruments can be bootstrapped for:
 
-- [LiteStar](https://lite-bootstrap.modern-python.org/integrations/litestar)
-- [FastStream](https://lite-bootstrap.modern-python.org/integrations/faststream)
-- [FastAPI](https://lite-bootstrap.modern-python.org/integrations/fastapi)
-- [FastMCP](https://lite-bootstrap.modern-python.org/integrations/fastmcp)
-- [services and scripts without frameworks](https://lite-bootstrap.modern-python.org/integrations/free)
+- [LiteStar](https://lite-bootstrap.modern-python.org/integrations/litestar/)
+- [FastStream](https://lite-bootstrap.modern-python.org/integrations/faststream/)
+- [FastAPI](https://lite-bootstrap.modern-python.org/integrations/fastapi/)
+- [FastMCP](https://lite-bootstrap.modern-python.org/integrations/fastmcp/)
+- [services and scripts without frameworks](https://lite-bootstrap.modern-python.org/integrations/free/)
 
 ## Lifecycle constraints
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,4 +22,3 @@ Those instruments can be bootstrapped for:
 - [FastAPI](integrations/fastapi.md)
 - [FastMCP](integrations/fastmcp.md)
 - [services and scripts without frameworks](integrations/free.md)
----


### PR DESCRIPTION
Follow-up tidy of the minor items noted during the home-page docs audit (#146).

- Remove the dangling `---` thematic break at the end of `docs/index.md` (nothing followed it).
- Add trailing slashes to the README's integration links so they resolve to the mkdocs directory URLs directly instead of relying on a host redirect.

`uv run mkdocs build --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)