### PR TITLE
ci: guard docs drift — mkdocs --strict as a PR check + link/anchor validation

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -16,6 +16,14 @@ jobs:
       - run: uv python pin 3.10
       - run: just install lint-ci
 
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: astral-sh/setup-uv@v8.2.0
+      - run: just docs-build
+
   pytest:
     runs-on: ubuntu-latest
     strategy:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs
-mkdocs-material
+mkdocs>=1.6,<2
+mkdocs-material>=9,<10

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/modern-python/lite-bootstrap
 docs_dir: docs
 edit_uri: edit/main/docs/
 nav:
+  - Overview: index.md
   - Introduction:
       - Quickstart: introduction/quickstart.md
       - Installation: introduction/installation.md
@@ -50,6 +51,12 @@ theme:
       toggle:
         icon: material/brightness-4
         name: Switch to system preference
+
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn
 
 markdown_extensions:
   - toc:


### PR DESCRIPTION
Ports the docs CI drift guard (from `faststream-outbox`) to this repo.

- **`mkdocs.yml`** — `validation:` block so broken internal links, broken `#anchor` fragments, and orphaned pages fail the `--strict` build; also adds the previously-orphaned `index.md` (the hero landing page) to nav as **Overview** so the new `omitted_files` check passes. The homepage already served at `/`; this only gives it a nav entry.
- **`.github/workflows/_checks.yml`** — parallel `docs` job running `just docs-build` on PRs.
- **`docs/requirements.txt`** — pin `mkdocs>=1.6,<2`, `mkdocs-material>=9,<10`.

Verified: clean strict build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)