### PR TITLE
fix(planning): repoint change links to flat 2.0.0 files

### DIFF
--- a/planning/decisions/2026-06-24-teardown-marker-accepted-limits.md
+++ b/planning/decisions/2026-06-24-teardown-marker-accepted-limits.md
@@ -8,7 +8,7 @@ superseded_by: null
 # Accepted limits of the unified teardown-attach marker
 
 **Decision:** The `_lite_bootstrap_teardown_attached` marker introduced in
-[unify-teardown-attach](../changes/2026-06-24.01-unify-teardown-attach/design.md)
+[unify-teardown-attach](../changes/2026-06-24.01-unify-teardown-attach.md)
 (#130) carries two known limits that we accept rather than design around:
 FastMCP detects double-attach via the attribute marker (not a provider-list scan),
 and Litestar tags the shared `AppConfig` (not a built app). Both surfaced in the

--- a/planning/releases/1.1.0.md
+++ b/planning/releases/1.1.0.md
@@ -2,7 +2,7 @@
 
 **1.1.0 is a minor release. No intentional public-API breakage.** The two behavior changes that could affect existing code are fixes to genuine bugs and are called out in *Behavior changes* below.
 
-This release closes a 26-finding bug-audit cycle (the audit lives in `planning/audits/`, the implementation arc in `planning/changes/2026-06-05.01-bug-audit-v2/`, and the retro in `planning/retros/`). The changes split across four shipped PRs:
+This release closes a 26-finding bug-audit cycle (the audit lives in `planning/audits/`, the implementation arc in `planning/changes/2026-06-05.01-bug-audit-v2.md`, and the retro in `planning/retros/`). The changes split across four shipped PRs:
 
 - **#108** — Lifecycle & teardown correctness (10 findings)
 - **#109** — Config UX & security validation (6 findings)
@@ -68,12 +68,12 @@ Aside from the two *Behavior changes* called out above, every public API behaves
 The 26-fix list with full file:line references and rationale is in:
 
 - `planning/audits/2026-06-05-bug-audit-v2.md` — the audit
-- `planning/changes/2026-06-05.01-bug-audit-v2/design.md` — the 3-PR breakdown
+- `planning/changes/2026-06-05.01-bug-audit-v2.md` — the 3-PR breakdown
 - `planning/retros/2026-06-05-bug-audit-v2-retro.md` — what the cycle taught us
 
 ## References
 
 - Audit: [`planning/audits/2026-06-05-bug-audit-v2.md`](../audits/2026-06-05-bug-audit-v2.md)
-- Sequencing: [`planning/changes/2026-06-05.01-bug-audit-v2/design.md`](../changes/2026-06-05.01-bug-audit-v2/design.md)
+- Sequencing: [`planning/changes/2026-06-05.01-bug-audit-v2.md`](../changes/2026-06-05.01-bug-audit-v2.md)
 - Retro: [`planning/retros/2026-06-05-bug-audit-v2-retro.md`](../retros/2026-06-05-bug-audit-v2-retro.md)
 - PRs: [#108](https://github.com/modern-python/lite-bootstrap/pull/108), [#109](https://github.com/modern-python/lite-bootstrap/pull/109), [#110](https://github.com/modern-python/lite-bootstrap/pull/110), [#111](https://github.com/modern-python/lite-bootstrap/pull/111)

--- a/planning/releases/1.2.0.md
+++ b/planning/releases/1.2.0.md
@@ -25,4 +25,4 @@ Internal-only changes that do not affect the public API: FastMCP's double-attach
 ## References
 
 - PRs: [#129](https://github.com/modern-python/lite-bootstrap/pull/129), [#130](https://github.com/modern-python/lite-bootstrap/pull/130), [#132](https://github.com/modern-python/lite-bootstrap/pull/132)
-- Design bundles and the decisions behind the rejected/limited options: `planning/changes/2026-06-23.01-structured-log-payload/`, `planning/changes/2026-06-24.01-unify-teardown-attach/`, `planning/changes/2026-06-24.02-otel-excluded-urls-home/`, and `planning/decisions/`.
+- Design bundles and the decisions behind the rejected/limited options: `planning/changes/2026-06-23.01-structured-log-payload.md`, `planning/changes/2026-06-24.01-unify-teardown-attach.md`, `planning/changes/2026-06-24.02-otel-excluded-urls-home.md`, and `planning/decisions/`.

--- a/planning/retros/2026-06-01-audit-implementation-retro.md
+++ b/planning/retros/2026-06-01-audit-implementation-retro.md
@@ -4,8 +4,8 @@
 **Scope:** PRs #89–103 across two sequenced waves
 **Parent docs:**
 - Audit: [2026-05-31-bug-refactor-audit.md](../audits/2026-05-31-bug-refactor-audit.md)
-- Sequencing 1: [2026-05-31-audit-implementation-sequencing.md](../changes/2026-05-31.01-audit-implementation/design.md)
-- Sequencing 2: [2026-06-01-deferred-refactors-sequencing.md](../changes/2026-06-01.03-deferred-refactors/design.md)
+- Sequencing 1: [2026-05-31-audit-implementation-sequencing.md](../changes/2026-05-31.01-audit-implementation.md)
+- Sequencing 2: [2026-06-01-deferred-refactors-sequencing.md](../changes/2026-06-01.03-deferred-refactors.md)
 
 ---
 

--- a/planning/retros/2026-06-05-bug-audit-v2-retro.md
+++ b/planning/retros/2026-06-05-bug-audit-v2-retro.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-05
 **Cycle:** Audit → 3-PR sequencing → execute
-**Inputs:** [bug-audit-v2.md](../audits/2026-06-05-bug-audit-v2.md), [sequencing](../changes/2026-06-05.01-bug-audit-v2/design.md), [PR1 plan](../changes/2026-06-05.01-bug-audit-v2/plan-pr1-lifecycle.md), [PR2 plan](../changes/2026-06-05.01-bug-audit-v2/plan-pr2-config-security.md), [PR3 plan](../changes/2026-06-05.01-bug-audit-v2/plan-pr3-hygiene-ci.md)
+**Inputs:** [bug-audit-v2.md](../audits/2026-06-05-bug-audit-v2.md), [sequencing](../changes/2026-06-05.01-bug-audit-v2.md), [PR1 plan](../changes/2026-06-05.01-bug-audit-v2/plan-pr1-lifecycle.md), [PR2 plan](../changes/2026-06-05.01-bug-audit-v2/plan-pr2-config-security.md), [PR3 plan](../changes/2026-06-05.01-bug-audit-v2/plan-pr3-hygiene-ci.md)
 **Outcome:** 26/26 audit findings shipped to main across three PRs (#108, #109, #110).
 
 ## Numbers


### PR DESCRIPTION
Repoints planning doc links broken by the 2.0.0 folder->file flatten: \`changes/<slug>/{design,change,plan}.md\` and bare \`changes/<slug>/\` -> \`changes/<slug>.md\`, only where the flat target exists. Pre-existing \`changes/active/\` and \`changes/archive/\` dead links (never ours) are left untouched. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)