### PR TITLE
fix(planning): salvage archived change links to flat 2.0.0 files

### DIFF
--- a/planning/changes/2026-06-13.01-portable-planning-convention.md
+++ b/planning/changes/2026-06-13.01-portable-planning-convention.md
@@ -326,7 +326,7 @@ triggers; items graduate from here into `changes/active/` bundles.
 ### 11. Dogfood — this change is its own bundle
 
 This adoption is itself a change, so it lands as
-`planning/changes/active/2026-06-13.01-portable-planning-convention/`:
+`planning/changes/2026-06-13.01-portable-planning-convention.md`:
 
 - This `design.md` is written there now (during brainstorming) — the first use
   of the new layout.


### PR DESCRIPTION
Salvages pre-existing dead links: \`changes/archive/<slug>/…\` (and \`active/<slug>/…\`) -> \`changes/<slug>.md\`, only where the flat file exists at top level. Placeholder refs (\`YYYY-MM-DD.NN-<slug>\`) left as-is. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)