### PR TITLE
ci: run fastmcp on the 3.14t free-threaded leg

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -56,7 +56,7 @@ jobs:
           - python-version: "3.13t"
             extras: "logging,sentry,fastapi,faststream,fastapi-metrics,faststream-metrics"
           - python-version: "3.14t"
-            extras: "logging,sentry,fastapi,litestar,faststream,fastapi-metrics,litestar-metrics,faststream-metrics"
+            extras: "logging,sentry,fastapi,litestar,faststream,fastmcp,fastapi-metrics,litestar-metrics,faststream-metrics,fastmcp-metrics"
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.2.0
@@ -65,7 +65,7 @@ jobs:
           cache-dependency-glob: "**/pyproject.toml"
       - run: uv python install ${{ matrix.python-version }}
       - run: uv venv --python ${{ matrix.python-version }}
-      - name: Install core + ft-ready extras (orjson/otl/pyroscope/fastmcp excluded)
+      - name: Install core + ft-ready extras (orjson/otl/pyroscope excluded; litestar/fastmcp 3.14t-only)
         run: uv pip install ".[${{ matrix.extras }}]"
       - name: Free-threaded smoke test
         run: .venv/bin/python scripts/ft_smoke.py

--- a/architecture/free-threading.md
+++ b/architecture/free-threading.md
@@ -12,7 +12,7 @@ its extra, not `lite-bootstrap` itself.
 | core, `logging`, `sentry` | ✅ | ✅ | pure Python; `logging` uses the stdlib-json serializer fallback when `orjson` is absent |
 | `fastapi`/`faststream` (+ `-sentry`/`-logging`/`-metrics`) | ✅ | ✅ | pure Python + `pydantic-core` ft wheels |
 | `litestar` (+ `litestar-metrics`) | ❌ | ✅ | `msgspec` gates `Py_GIL_DISABLED` to Python 3.14+ — its `_core.c` contains `#error "Py_GIL_DISABLED is only supported in Python 3.14+"` (v0.21.1), so the source build fails on 3.13t. See [`planning/deferred.md`](../planning/deferred.md) |
-| `fastmcp` (+ `fastmcp-metrics`) | ❌ | ❌ | 3.13t: `cffi` (via `fastmcp`→`cryptography`) refuses to build free-threaded. 3.14t: `fastmcp` pulls bare `opentelemetry-api` without `opentelemetry-sdk`, so `import lite_bootstrap` still fails. See [`planning/deferred.md`](../planning/deferred.md) |
+| `fastmcp` (+ `fastmcp-metrics`) | ❌ | ✅ | 3.13t: `cffi` (via `fastmcp`→`cryptography`) refuses to build free-threaded. 3.14t: works (on the leg) since the opentelemetry api/sdk split. See [`planning/deferred.md`](../planning/deferred.md) |
 | `orjson` (opt-in speedup) | ❌ | ❌ | no ft wheels, build refuses ft ([ijl/orjson#530](https://github.com/ijl/orjson/issues/530)). Omit it on ft; the serializer falls back to stdlib json |
 | `otl` (gRPC exporter) | ❌ | ❌ | needs `grpcio`, no ft wheels ([grpc/grpc#38762](https://github.com/grpc/grpc/issues/38762)). An HTTP-exporter path is deferred (`planning/deferred.md`) |
 | `pyroscope` | ❌ | ❌ | `pyroscope-io` is abi3-only, unmaintained, no ft wheels ([`planning/deferred.md`](../planning/deferred.md)) |
@@ -20,8 +20,9 @@ its extra, not `lite-bootstrap` itself.
 The CI matrix (`.github/workflows/_checks.yml`, `free-threaded` job) installs
 per Python version to match this table exactly: the 3.13t leg's extras stop at
 `logging,sentry,fastapi,faststream,fastapi-metrics,faststream-metrics`; the
-3.14t leg adds `litestar,litestar-metrics`. `orjson`, `otl`, `pyroscope`, and
-`fastmcp`/`fastmcp-metrics` are excluded from both legs.
+3.14t leg adds `litestar,litestar-metrics,fastmcp,fastmcp-metrics`. `orjson`,
+`otl`, and `pyroscope` are excluded from both legs; `fastmcp` runs on 3.14t only
+(3.13t is `cffi`-blocked).
 
 ## The `orjson` fallback
 

--- a/planning/deferred.md
+++ b/planning/deferred.md
@@ -28,33 +28,19 @@ this repo.
 **Trigger:** `pyroscope-io` ships ft wheels (or a maintained ft-capable
 replacement appears).
 
-### fastmcp on free-threaded Python
+### fastmcp on free-threaded Python 3.13 (cffi gates Py_GIL_DISABLED to 3.14+)
 
-`fastmcp` and `fastmcp-metrics` are excluded from both ft CI legs
-(`.github/workflows/_checks.yml`) and from `scripts/ft_smoke.py`'s local
-verification commands, for two separate, independent reasons — one per leg:
-
-- **3.13t (install-time, upstream, not fixable here):** `fastmcp` →
-  `fastmcp-slim[server]` → `joserfc` → `cryptography` → `cffi`, and `cffi`
-  (v2.1.0) refuses to build on free-threaded 3.13: "CFFI does not support the
-  free-threaded build of CPython 3.13. Upgrade to free-threaded 3.14 or newer
-  to use CFFI with the free-threaded build." — an upstream gate, not a
-  build-environment problem, the same shape as msgspec's 3.13t gate below.
-  Reproduced 2026-07-18: `uv pip install --python <3.13t venv> ".[fastmcp]"`
-  fails building `cffi`.
-- **3.14t (now importable):** `fastmcp` transitively pulls bare
-  `opentelemetry-api` with no other `opentelemetry-*` package. The three
-  incomplete-opentelemetry-stack bugs this exposed are all fixed — the
-  `import_checker` namespace crash and the unconditional grpc-exporter import in
-  `changes/2026-07-18.01`, and the api-vs-sdk conflation
-  (`opentelemetry_instrument.py` importing `opentelemetry.sdk.*` and
-  `check_dependencies()` under the api-only flag) in `changes/2026-07-19.01`. So
-  `uv pip install ".[fastmcp]"` + `import lite_bootstrap` now succeeds on 3.14t;
-  it is simply not yet wired into the 3.14t leg's extras.
-
-**Trigger:** `cffi` ships free-threaded 3.13 wheels (unblocks 3.13t), **or** add
-`fastmcp`/`fastmcp-metrics` to the 3.14t leg's extras in `_checks.yml` (import
-now works there).
+`fastmcp`/`fastmcp-metrics` run on the **3.14t** ft CI leg
+(`.github/workflows/_checks.yml`) but are excluded from **3.13t**: `fastmcp` →
+`fastmcp-slim[server]` → `joserfc` → `cryptography` → `cffi`, and `cffi` (v2.1.0)
+refuses to build on free-threaded 3.13 ("CFFI does not support the free-threaded
+build of CPython 3.13. Upgrade to free-threaded 3.14 or newer to use CFFI with
+the free-threaded build.") — an upstream gate, the same shape as msgspec's 3.13t
+gate below. Reproduced 2026-07-18: `uv pip install --python <3.13t venv>
+".[fastmcp]"` fails building `cffi`. (The three opentelemetry-stack import bugs
+that previously also blocked 3.14t are fixed in `changes/2026-07-18.01` and
+`changes/2026-07-19.01`.)
+**Trigger:** `cffi` ships free-threaded 3.13 wheels.
 
 ### litestar on free-threaded Python 3.13 (msgspec gates Py_GIL_DISABLED to 3.14+)
 


### PR DESCRIPTION
Now that #154's opentelemetry api/sdk split lets `lite-bootstrap[fastmcp]` import in an api-only environment, `fastmcp`/`fastmcp-metrics` install and smoke-pass on 3.14t. This adds them to the 3.14t free-threaded CI leg's extras.

3.13t stays excluded — `cffi` (via `fastmcp`→`cryptography`) refuses to build on free-threaded 3.13 (upstream gate). Documented in `planning/deferred.md`.

Verified locally on a real 3.14t interpreter: the full 3.14t extra set installs and `scripts/ft_smoke.py` passes. Docs promoted: `architecture/free-threading.md` matrix (fastmcp 3.14t ✅).

🤖 Generated with [Claude Code](https://claude.com/claude-code)