### PR TITLE
docs(release): finalize 1.3.0 release notes

### DIFF
--- a/planning/releases/1.3.0.md
+++ b/planning/releases/1.3.0.md
@@ -12,12 +12,13 @@ plus two import-safety fixes surfaced while verifying it.
   was the mandatory `orjson` dependency (below). Core, `logging`, `sentry`,
   `fastapi`, and `faststream` (plus their `-sentry`/`-logging`/`-metrics`
   combos) now install and run on both 3.13t and 3.14t. `litestar` (+
-  `litestar-metrics`) lands on **3.14t only** — `msgspec`, which `litestar`
-  requires unconditionally, gates free-threaded support to Python 3.14+ and
-  fails to build from source on 3.13t. `fastmcp` (+ `fastmcp-metrics`), `otl`
-  (the gRPC OTLP exporter needs `grpcio`, which has no ft wheels), and
-  `pyroscope` (`pyroscope-io` is abi3-only and unmaintained) remain
-  unavailable on free-threaded builds pending upstream fixes. See
+  `litestar-metrics`) and `fastmcp` (+ `fastmcp-metrics`) land on **3.14t
+  only** — `msgspec` (litestar) and `cffi` (fastmcp, via cryptography) both
+  gate free-threaded support to Python 3.14+ and fail to build from source on
+  3.13t. The gRPC `otl` exporter (`grpcio` has no ft wheels — use the new
+  `otl-http` extra instead) and `pyroscope` (`pyroscope-io` is abi3-only and
+  unmaintained) remain unavailable on free-threaded builds pending upstream
+  fixes. See
   [`architecture/free-threading.md`](../../architecture/free-threading.md) for
   the full support matrix and [`planning/deferred.md`](../deferred.md) for the
   ecosystem blockers.
@@ -60,8 +61,17 @@ plus two import-safety fixes surfaced while verifying it.
   is absent, `bootstrap()` emits an `InstrumentDependencyMissingWarning` naming
   the extra to install (`[otl]` for gRPC, `[otl-http]` for HTTP); see
   [`architecture/instruments.md`](../../architecture/instruments.md).
+- **The OpenTelemetry instrument no longer assumes the SDK is present when only
+  the API is.** `is_opentelemetry_installed` (`find_spec("opentelemetry")`) is
+  true with just `opentelemetry-api`, but the instrument imports
+  `opentelemetry.sdk.*` — a separate distribution. An api-only environment
+  (e.g. `lite-bootstrap[fastmcp]`) therefore still crashed at the sdk import
+  even after the exporter guard above. A new `is_opentelemetry_sdk_installed`
+  flag gates the sdk imports, and `check_dependencies()` requires both the api
+  and the sdk. With all three fixes, `lite-bootstrap[fastmcp]` imports and runs
+  on free-threaded 3.14t.
 
-Both bugs are not ft-specific — they affect any environment with a partial
+These bugs are not ft-specific — they affect any environment with a partial
 `opentelemetry` stack — but ft verification work is what surfaced them.
 
 ## Backwards compatibility
@@ -73,4 +83,6 @@ build once `orjson` is installed (directly, or via the `[orjson]` extra).
 
 ## References
 
-- Design bundle: `planning/changes/2026-07-18.01-free-threaded-python-support.md`
+- Design bundle: `planning/changes/2026-07-18.01-free-threaded-python-support.md`,
+  `planning/changes/2026-07-19.01-fix-otel-api-sdk-conflation.md`,
+  `planning/changes/2026-07-19.02-otlp-http-exporter.md`.


### PR DESCRIPTION
Finalize the `1.3.0` release note before tagging. It was written at #153 and understated the shipped state:

- **fastmcp** was listed as "unavailable on free-threaded builds" — actually #154 (api/sdk fix) made `lite-bootstrap[fastmcp]` importable and #155 put it on the **3.14t** leg. Now grouped with litestar as 3.14t-only (3.13t blocked by cffi).
- The **api/sdk conflation fix** (#154) — the fix that actually made `[fastmcp]` import — was missing from the bug-fix list. Added.
- References now list all three change files.

`release.yml` uses `planning/releases/1.3.0.md` verbatim as the GitHub Release body, so this must be accurate before the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)