### PR TITLE
chore(docs): use a builder-portable homepage check in the override template

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -3,7 +3,8 @@
   {{ super() }}
   {% set base = config.site_url if config.site_url.endswith('/') else config.site_url ~ '/' %}
   {% set card = base ~ 'assets/social-card.png' %}
-  {% set title = (page.title ~ ' · ' ~ config.site_name) if (page.title and not page.is_homepage) else config.site_name %}
+  {%- set is_home = nav.homepage and page.url == nav.homepage.url %}
+  {% set title = (page.title ~ ' · ' ~ config.site_name) if (page.title and not is_home) else config.site_name %}
   {% set description = page.meta.description if page.meta and page.meta.description else config.site_description %}
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="{{ config.site_name }}">


### PR DESCRIPTION
## Why

`page.is_homepage` is a MkDocs `Page` property with no equivalent in Zensical, which the org is
evaluating as a future docs builder (modern-python/.github#60). It fails **silently**, not loudly:
at Zensical 0.0.59 the property does not exist anywhere in the source, and an undefined name
resolves falsy in MiniJinja — so the home page would fall through to the non-home branch and emit a
wrong `og:title` / `twitter:title` with no warning.

`nav.homepage` is exposed by both builders — MkDocs documents it as `homepage: Page | None`
(<https://www.mkdocs.org/dev-guide/themes/>), and Zensical serializes it in
`crates/zensical/src/structure/nav/view.rs` — so comparing `page.url` against it is portable.

Part of modern-python/.github#71, which makes the same change in each repo with an
`overrides/main.html`.

## Design

`{%- set is_home = nav.homepage and page.url == nav.homepage.url %}`, then `not is_home` where
`not page.is_homepage` used to be.

- The `nav.homepage and` guard is load-bearing: MkDocs types it `Page | None`. When it is `None`
  the expression is falsy, which matches `is_homepage` being `False` on every page of a site with
  no home page.
- The `{%-` left-trim is also load-bearing: without it the new tag adds a blank line to every
  rendered page.

## Non-goals

Not a Zensical migration. #60 stays open and stays blocked on unrelated gaps (`exclude_docs`,
`validation.omitted_files`). This change is a no-op under MkDocs today and does not depend on that
work landing.

## Verification

Full-site build diff with the pinned toolchain, `main` vs this branch:

```
uvx --with-requirements docs/requirements.txt mkdocs build --strict -d <dir>
diff -r <before> <after>
```

`--strict` passes on both, and the output is **byte-identical across all 9 pages** — including
`index.html`'s `<title>`, `og:title` and `twitter:title`, which are what this touches.
