### PR TITLE
docs(agents): drop the fact-placement convention from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,63 +21,13 @@ there and is load-bearing throughout.
 owns one observability concern, `bootstrappers/<framework>_bootstrapper.py` owns one framework's
 bindings, and `import_checker.py` owns every optional-dependency probe. Read them.
 
-What reading them will not tell you is why four shapes are load-bearing rather than incidental:
-
-- The instrument × framework matrix stays on the **instrument** axis, not a per-framework adapter
-  axis ([ADR-0002](docs/adr/0002-keep-per-instrument-axis.md)).
-- The double-bootstrap guard is an attribute marker, with two known limits accepted
-  ([ADR-0003](docs/adr/0003-teardown-marker-accepted-limits.md)).
-- OpenTelemetry's URL-exclusion policy stays in one method reading its siblings, rather than being
-  contributed per instrument ([ADR-0004](docs/adr/0004-excluded-urls-stay-one-method.md)).
-- `orjson` is an opt-in extra ([ADR-0005](docs/adr/0005-orjson-is-opt-in.md)) and
-  `typing-extensions` is core's only runtime dependency
-  ([ADR-0007](docs/adr/0007-core-declares-typing-extensions.md)) — together, the reason every
-  surface this library controls installs on free-threaded CPython.
-
-Behaviour detail has no prose home: it lives in the code and in the `INVARIANT:`-marked tests.
-Before writing prose about a capability, run the admission check in **Where a fact goes**.
-
 ## Workflow
 
-**The spec for a change is its PR body**, not a committed file: why, design, non-goals,
-verification, reviewed with the diff. There is no change file and no lane to choose. A trivial PR
-(typo, dep bump, formatter, CI tweak) ships a conventional-commit title with no body ceremony.
-
-Two things outlive the PR, and there are exactly two places to put them: an alternative **rejected**
-with reasoning becomes an ADR in [`docs/adr/`](docs/adr/) (`NNNN-slug.md`, sequential, with a revisit
-trigger), and real work **not scheduled** becomes a GitHub issue. There is no third state, and no
-separate truth-home directory — a behaviour change is reviewed with the diff, not promoted to a page.
-
-### Where a fact goes
-
-Four homes, one owner each:
-
-| Home | Holds |
-|---|---|
-| `lite_bootstrap/` | anything readable from the module — the default |
-| a named test | an **invariant**: must stay true, and a change could silently break it |
-| `docs/adr/` | a rejected alternative, with the reasoning that would otherwise be re-litigated |
-| `README.md` and `docs/` | anything a user needs |
-
-Before writing a line anywhere:
-
-> Can an agent get this by reading `lite_bootstrap/`? → **don't write it.**
-> Would a wrong change here fail a test? → it belongs **in the test**, not in prose.
-> Does a user need it? → **`README.md` or `docs/`**.
-> Otherwise it does not get written.
-
-**Prose about mechanism has no home. There is no file to add a paragraph to.** This file included:
-it is always loaded, so a line that restates a docstring, a justfile comment, or `pyproject.toml`
-costs every turn and rots in two places at once. This project tempts that failure mode particularly
-hard, because the instrument × framework matrix invites a written index of cells that the file
-layout already gives you.
+Real work **not scheduled** becomes a GitHub issue.
 
 An invariant is a test whose name is the claim, with a docstring opening `INVARIANT:` and a second
 paragraph naming **what breaks it** — design rationale, not a report of what this one test catches.
-Nothing enforces that docstring shape; it is read at review time. A relative link to an ADR *is*
-checked — CI runs lychee `--offline` over every `.md` — but a path named in a docstring or a comment
-is not. Both ADRs and `INVARIANT:` docstrings ratchet: nothing prunes a record once its call is
-settled. Keeping them lean is a standing habit.
+Nothing enforces that docstring shape; it is read at review time.
 
 ## Code style
 


### PR DESCRIPTION
## Why

AGENTS.md carried a per-repo copy of a doc-placement convention: a four-homes table, an admission check to run "before writing a line anywhere", an ADR row prescribing `NNNN-slug.md` and revisit triggers, a ratchet rule, and an index of the repo's ADRs.

Doc placement is a domain-modeling convention. Restating it per repo means 25 copies that can drift from it, in a file loaded on every turn — the failure the removed text itself named: "it is always loaded, so a line that restates a docstring… costs every turn and rots in two places at once."

The local ADR rule was also weaker than the convention it duplicated: no reversibility gate, so any non-obvious rejected alternative qualified. That is how a since-dropped ADR rejecting a gRPC bootstrapper got written — trivially reversible, nothing built, and it would have been filtered before its argument was examined.

## Design

`AGENTS.md` goes from 103 lines to 56. Removed:

- the `### Where a fact goes` section in full — four-homes table, the "before writing a line anywhere" admission check, "prose about mechanism has no home", the ratchet rule
- **Architecture**'s "why four shapes are load-bearing" list and its five ADR links, plus the "Behaviour detail has no prose home… run the admission check" tail
- **Workflow**'s "the spec for a change is its PR body" rule, "there is no change file and no lane to choose", and "there is no separate truth-home directory"

`grep -i adr AGENTS.md` now returns nothing.

Kept: Project Overview, Commands, Architecture's file-layout paragraph, Code style, Type checking, one Workflow fact (unscheduled work becomes an issue), and the `INVARIANT:` docstring shape.

## Non-goals

- No ADR is changed, removed or renumbered. `docs/adr/` and its nine records are untouched — only the prose that indexed them and prescribed when to write one.
- No test is changed here.
- No replacement pointer to the convention is added, by design.
- This is the pilot for the same edit across 24 other repos; those are separate PRs and none is open.

## Companion change

`modern-di` enforces the `INVARIANT:` docstring shape with `tests/test_invariant_census.py`; that test is being dropped separately. The shape stays documented in AGENTS.md and unenforced by CI, checked at review time — which is what this file now says.

## Verification

- `grep -i adr AGENTS.md` → no matches.
- No dangling cross-reference: the only pointer to **Where a fact goes** was the Architecture tail, removed in the same change.
- Trailing newline preserved for `eof-fixer`. Every removed markdown link was relative to a target that still exists, so the lychee gate is unaffected.
