### PR TITLE
docs(agents): point at the domain-modeling skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,9 @@ Two suppression spellings recur and are both correct as written: `# ty: ignore[i
 on a framework subclass's `is_configured` classmethod, which narrows its parameter type where `ty`
 enforces invariance, and `# ty: ignore[unresolved-attribute]` on the optional OTel/pyroscope symbols
 whose guard `ty` does not follow.
+
+## Agent skills
+
+- **Domain docs** — [`CONTEXT.md`](CONTEXT.md) owns the vocabulary and [`docs/adr/`](docs/adr/)
+  holds the decisions. Both follow the `domain-modeling` skill: invoke it when writing either,
+  rather than restating its rules here.


### PR DESCRIPTION
## Why

#188 removed the fact-placement convention from `AGENTS.md`, including the rules for what earns an ADR, and deliberately added no replacement pointer. That left `CONTEXT.md` and `docs/adr/` in the repo with nothing saying which convention governs them.

This names the convention without restating it — the restating is what #188 removed.

## Design

One `## Agent skills` section at the end, matching the shape `modern-di`, `httpware` and `faststream-outbox` already use:

> - **Domain docs** — `CONTEXT.md` owns the vocabulary and `docs/adr/` holds the decisions. Both follow the `domain-modeling` skill: invoke it when writing either, rather than restating its rules here.

Deliberately absent: the skill's admission test (hard to reverse / surprising without context / a real trade-off), ADR filename and numbering rules, and anything about revisit triggers. Those live in the skill, and duplicating them here is what #188 removed.

## Known limitation

`domain-modeling` is not shipped in this repo, so a contributor without it gets a name they cannot resolve. That is accepted: the pointer is aimed at agent sessions, and the alternative — restating the rules — is what this file just stopped doing.

## Verification

Both links are relative to targets that exist (`CONTEXT.md`, `docs/adr/`), so the lychee `--offline` gate resolves them.
