### PR TITLE
docs(adr): record that FastMCP 4 fired ADR 0001's revisit trigger

### DIFF
--- a/docs/adr/0001-fastmcp-teardown-via-provider-lifespan.md
+++ b/docs/adr/0001-fastmcp-teardown-via-provider-lifespan.md
@@ -25,6 +25,26 @@ The accepted cost is semantic: `Provider` is FastMCP's general extension abstrac
 resources and prompts, and using one purely for a shutdown callback is thin. A one-line comment at
 the registration site says so.
 
-**Revisit trigger:** FastMCP grows a first-class shutdown hook (an `on_shutdown` API, or a
-documented public way to compose a lifespan post-construction). At that point the provider is the
-indirect route and should be replaced by the direct one.
+## FastMCP 4 fired the trigger, and the replacement was rejected
+
+FastMCP 4 added `FastMCP.add_extension(extension: ServerExtension)`, whose
+`ServerExtension.lifespan()` is documented as "A context manager entered with the server's lifespan,
+exited on shutdown", to "start and stop resources an extension owns". That is literally the second
+clause of this ADR's original trigger, "a documented public way to compose a lifespan
+post-construction". The first clause did not fire: `on_shutdown` and `on_startup` are still absent
+in 4.0.3.
+
+Rejected: **switch `_TeardownProvider` to a `ServerExtension`.** It trades a thin misuse for a
+client-visible one. `ServerExtension.identifier` is a required reverse-DNS string, validated at
+registration, and its own comment states it is "advertised under `ServerCapabilities.extensions`".
+Registering one purely for a shutdown callback would announce a protocol capability the bootstrapper
+does not implement, where the `Provider` route's thinness is invisible outside the process. A
+teardown hook must not change what the server tells its clients it can do.
+
+Reinforcing it: the `fastmcp` extra declares an unbounded `"fastmcp"`, so `ServerExtension` may not
+exist at runtime. Adopting it would force a `fastmcp>=4` floor on an optional extra to buy a
+semantically worse hook.
+
+**Revisit trigger:** FastMCP grows a shutdown hook that is neither client-visible nor tied to
+another abstraction's semantics, most likely an `on_shutdown` API. `add_extension` does not qualify
+and should not be revisited on version bumps alone.


### PR DESCRIPTION
ADR 0001 chose `FastMCP.add_provider()` for teardown and set a revisit trigger: FastMCP grows a
first-class shutdown hook, either an `on_shutdown` API or a documented public way to compose a
lifespan post-construction.

Checked against `fastmcp` 4.0.3. The trigger fired on its second clause, but the replacement it
pointed at is worse than what we have, so this records the evaluation and narrows the trigger rather
than changing the decision.

- `on_shutdown` and `on_startup` are still absent, so the first clause did not fire.
- `add_extension(ServerExtension)` exists, and `ServerExtension.lifespan()` is documented as
  "A context manager entered with the server's lifespan, exited on shutdown", to "start and stop
  resources an extension owns". That satisfies the second clause literally.
- But `ServerExtension.identifier` is a required reverse-DNS string, validated at registration, and
  documented as "advertised under `ServerCapabilities.extensions`". Registering one purely for a
  shutdown callback would announce a protocol capability the bootstrapper does not implement. The
  `Provider` route's thinness is invisible outside the process; this would not be.
- The `fastmcp` extra declares an unbounded `"fastmcp"`, so `ServerExtension` may not exist at
  runtime. Adopting it would force a `fastmcp>=4` floor on an optional extra.

The trigger now names a hook that is neither client-visible nor tied to another abstraction's
semantics, and says explicitly that `add_extension` does not qualify, so this does not get
re-litigated on every version bump.

Docs only, no code change.