### PR TITLE
feat(logging): configurable standard-library log filters

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,3 +57,12 @@ and traceback together. One event is one rendered line is one physical line of s
 never diverge.
 _Avoid_: formatted message — reserve that for Sentry's own `logentry.formatted` field, which holds
 a rendered line only until the seam lifts the message out of it.
+
+**Record filter**:
+A `logging.Filter` attached to a named standard-library logger through `logging_record_filters`. It
+runs inside `Logger.handle`, so it sees a `LogRecord` before any handler renders it and before
+Sentry's patched `callHandlers` turns it into an issue; it may rewrite the record or drop it. The
+logger name is exact — a filter on `package` never sees `package.child`.
+_Avoid_: processor — a structlog processor runs on an event dict inside the rendering chain, too
+late to change what Sentry captured; `logging_extra_processors` takes those. Also avoid bare
+"filter" where a handler filter or `structlog.stdlib.filter_by_level` could be meant.

--- a/docs/introduction/configuration.md
+++ b/docs/introduction/configuration.md
@@ -128,12 +128,9 @@ config = FastAPIConfig(
 
 ### Filtering standard-library log records
 
-`logging_record_filters` maps a logger name to the filters to attach to it. Each filter is a plain
-`logging.Filter`, run on every record that logger emits — before any handler renders it and before
-Sentry turns it into an issue. A filter may leave the record alone, rewrite it, or return `False` to
-drop it entirely.
-
-Use it to demote a third-party failure you already handle, without touching that library's code:
+`logging_record_filters` attaches `logging.Filter` instances to loggers by name. A filter sees every
+record its logger emits, before any handler renders it, and may rewrite the record or return `False`
+to drop it — useful for demoting a third-party error you already handle:
 
 ```python
 import logging
@@ -141,11 +138,9 @@ import logging
 from lite_bootstrap import FreeBootstrapper, FreeConfig
 
 
-class ExpectedThirdPartyFailureFilter(logging.Filter):
-    """Demote the one failure this service already retries; leave every other error alone."""
-
+class ExpectedFailureFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
-        if record.levelno == logging.ERROR and "RequestTimedOutError" in record.getMessage():
+        if record.levelno == logging.ERROR and "expected failure" in record.getMessage():
             record.levelno = logging.WARNING
             record.levelname = "WARNING"
         return True
@@ -153,25 +148,17 @@ class ExpectedThirdPartyFailureFilter(logging.Filter):
 
 bootstrapper = FreeBootstrapper(
     bootstrap_config=FreeConfig(
-        logging_record_filters={
-            "some_library.internal.worker": (ExpectedThirdPartyFailureFilter(),),
-        },
+        logging_record_filters={"some_library.worker": (ExpectedFailureFilter(),)},
     ),
 )
 ```
 
-Both `levelno` and `levelname` must be set: handlers and Sentry read them independently.
-
-Two properties come from the standard library, not from `lite-bootstrap`:
-
-- **The logger name must be exact.** A filter on `some_library` does *not* see records from
-  `some_library.internal.worker`. `logging.Logger.handle` consults its own filters and then walks
-  its ancestors' *handlers*, never their filters. Name every logger you want filtered.
-- **`""` is the root logger**, and it too only sees records logged through the root logger itself —
-  not records that propagate up to it from a named logger.
-
-Teardown removes only the filters `lite-bootstrap` attached; anything your application or another
-library put on the same logger stays.
+- **Set both `levelno` and `levelname`** when changing a level: handlers read them independently.
+- **The logger name is exact.** A filter on `some_library` never sees `some_library.worker`, and
+  `""` is the root logger, matching only records logged through root itself. That is standard
+  `logging` behaviour: a logger consults its own filters, then its ancestors' *handlers*.
+- **Teardown removes only what it attached**, leaving filters your application put on the same
+  logger in place.
 
 ### Structlog Litestar
 

--- a/docs/introduction/configuration.md
+++ b/docs/introduction/configuration.md
@@ -114,6 +114,7 @@ Additional parameters:
 - `logging_buffer_capacity`
 - `logging_extra_processors`
 - `logging_unset_handlers`
+- `logging_record_filters` - standard-library `logging.Filter` instances to attach to named loggers (see below).
 - `logging_time_stamper` - a `structlog.processors.TimeStamper` instance controlling timestamp format (default: `TimeStamper(fmt="iso")`). Pass a custom instance to change the format or enable UTC:
 
 ```python
@@ -124,6 +125,53 @@ config = FastAPIConfig(
     logging_time_stamper=structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=True),
 )
 ```
+
+### Filtering standard-library log records
+
+`logging_record_filters` maps a logger name to the filters to attach to it. Each filter is a plain
+`logging.Filter`, run on every record that logger emits — before any handler renders it and before
+Sentry turns it into an issue. A filter may leave the record alone, rewrite it, or return `False` to
+drop it entirely.
+
+Use it to demote a third-party failure you already handle, without touching that library's code:
+
+```python
+import logging
+
+from lite_bootstrap import FreeBootstrapper, FreeConfig
+
+
+class ExpectedThirdPartyFailureFilter(logging.Filter):
+    """Demote the one failure this service already retries; leave every other error alone."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno == logging.ERROR and "RequestTimedOutError" in record.getMessage():
+            record.levelno = logging.WARNING
+            record.levelname = "WARNING"
+        return True
+
+
+bootstrapper = FreeBootstrapper(
+    bootstrap_config=FreeConfig(
+        logging_record_filters={
+            "some_library.internal.worker": (ExpectedThirdPartyFailureFilter(),),
+        },
+    ),
+)
+```
+
+Both `levelno` and `levelname` must be set: handlers and Sentry read them independently.
+
+Two properties come from the standard library, not from `lite-bootstrap`:
+
+- **The logger name must be exact.** A filter on `some_library` does *not* see records from
+  `some_library.internal.worker`. `logging.Logger.handle` consults its own filters and then walks
+  its ancestors' *handlers*, never their filters. Name every logger you want filtered.
+- **`""` is the root logger**, and it too only sees records logged through the root logger itself —
+  not records that propagate up to it from a named logger.
+
+Teardown removes only the filters `lite-bootstrap` attached; anything your application or another
+library put on the same logger stays.
 
 ### Structlog Litestar
 

--- a/lite_bootstrap/bootstrappers/litestar_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/litestar_bootstrapper.py
@@ -226,8 +226,12 @@ class LitestarLoggingInstrument(LoggingInstrument):
             exclude=excluded_paths or None,
         )
 
-    def bootstrap(self) -> None:
-        self._unset_handlers()
+    def _configure_structlog_loggers(self) -> None:
+        """Register Litestar's StructlogPlugin instead of calling ``structlog.configure`` directly.
+
+        Overriding this one step rather than ``bootstrap()`` keeps every other step the base
+        instrument performs — including attaching ``logging_record_filters``.
+        """
         self.bootstrap_config.application_config.plugins.append(
             StructlogPlugin(
                 config=StructlogConfig(
@@ -245,7 +249,6 @@ class LitestarLoggingInstrument(LoggingInstrument):
                 ),
             )
         )
-        self._configure_foreign_loggers()
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/lite_bootstrap/bootstrappers/litestar_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/litestar_bootstrapper.py
@@ -227,11 +227,7 @@ class LitestarLoggingInstrument(LoggingInstrument):
         )
 
     def _configure_structlog_loggers(self) -> None:
-        """Register Litestar's StructlogPlugin instead of calling ``structlog.configure`` directly.
-
-        Overriding this one step rather than ``bootstrap()`` keeps every other step the base
-        instrument performs — including attaching ``logging_record_filters``.
-        """
+        """Register Litestar's StructlogPlugin instead of calling ``structlog.configure`` directly."""
         self.bootstrap_config.application_config.plugins.append(
             StructlogPlugin(
                 config=StructlogConfig(

--- a/lite_bootstrap/instruments/logging_instrument.py
+++ b/lite_bootstrap/instruments/logging_instrument.py
@@ -165,16 +165,7 @@ class LoggingInstrument(BaseInstrument[LoggingConfig]):
         root_logger.setLevel(self.bootstrap_config.logging_log_level)
 
     def _attach_record_filters(self) -> None:
-        """Attach the configured filters to their loggers, remembering each pair for teardown.
-
-        A filter goes on the *logger*, not on a handler: `logging.Logger.handle` runs it before
-        `callHandlers`, which is where Sentry's `LoggingIntegration` patches in. A filter here
-        therefore sees — and can demote or drop — a record before any handler or Sentry does.
-
-        Standard-library semantics apply: the filter runs only for records emitted by that exact
-        logger, never for a child's. `""` is the root logger, and reaches only records logged
-        through the root logger itself.
-        """
+        """Attach each configured filter to its logger, remembering the pair for teardown."""
         for logger_name, record_filters in self.bootstrap_config.logging_record_filters.items():
             target_logger = logging.getLogger(logger_name)
             for record_filter in record_filters:

--- a/lite_bootstrap/instruments/logging_instrument.py
+++ b/lite_bootstrap/instruments/logging_instrument.py
@@ -73,6 +73,7 @@ class LoggingConfig(BaseConfig):
     logging_unset_handlers: list[str] = dataclasses.field(
         default_factory=list,
     )
+    logging_record_filters: dict[str, tuple[logging.Filter, ...]] = dataclasses.field(default_factory=dict)
     logging_time_stamper: "structlog.processors.TimeStamper | None" = None
     logging_enabled: bool = True
 
@@ -83,6 +84,9 @@ class LoggingInstrument(BaseInstrument[LoggingConfig]):
     missing_dependency_message = "structlog is not installed"
     _logger_factory: "MemoryLoggerFactory | None" = dataclasses.field(
         default_factory=lambda: None, init=False, repr=False, compare=False
+    )
+    _attached_filters: list[tuple[logging.Logger, logging.Filter]] = dataclasses.field(
+        default_factory=list, init=False, repr=False, compare=False
     )
 
     @property
@@ -160,15 +164,41 @@ class LoggingInstrument(BaseInstrument[LoggingConfig]):
         root_logger.addHandler(stream_handler)
         root_logger.setLevel(self.bootstrap_config.logging_log_level)
 
+    def _attach_record_filters(self) -> None:
+        """Attach the configured filters to their loggers, remembering each pair for teardown.
+
+        A filter goes on the *logger*, not on a handler: `logging.Logger.handle` runs it before
+        `callHandlers`, which is where Sentry's `LoggingIntegration` patches in. A filter here
+        therefore sees — and can demote or drop — a record before any handler or Sentry does.
+
+        Standard-library semantics apply: the filter runs only for records emitted by that exact
+        logger, never for a child's. `""` is the root logger, and reaches only records logged
+        through the root logger itself.
+        """
+        for logger_name, record_filters in self.bootstrap_config.logging_record_filters.items():
+            target_logger = logging.getLogger(logger_name)
+            for record_filter in record_filters:
+                target_logger.addFilter(record_filter)
+                self._attached_filters.append((target_logger, record_filter))
+
+    def _detach_record_filters(self) -> None:
+        """Remove only the filters this instrument attached, leaving any others in place."""
+        for target_logger, record_filter in self._attached_filters:
+            target_logger.removeFilter(record_filter)
+        self._attached_filters.clear()
+
     def bootstrap(self) -> None:
         self._unset_handlers()
         self._configure_structlog_loggers()
         self._configure_foreign_loggers()
+        self._attach_record_filters()
 
     def teardown(self) -> None:
         """Reset structlog and root logger.
 
         Root logger level is unconditionally set to WARNING; pre-existing user configuration is overwritten.
+        Filters from ``logging_record_filters`` are removed one pair at a time, so a filter the
+        application or another library put on the same logger survives.
 
         Best-effort cleanup: errors from individual ``handler.close()`` calls and from the memory
         logger factory's ``close_handlers()`` are collected and re-raised together via
@@ -188,6 +218,7 @@ class LoggingInstrument(BaseInstrument[LoggingConfig]):
                     errors.append((type(h).__name__, e))
             root_logger.setLevel(logging.WARNING)
         finally:
+            self._detach_record_filters()
             if self._logger_factory is not None:
                 try:
                     self._logger_factory.close_handlers()

--- a/tests/instruments/test_logging_record_filters.py
+++ b/tests/instruments/test_logging_record_filters.py
@@ -1,0 +1,378 @@
+import json
+import logging
+import typing
+
+import faststream.asgi
+import pytest
+import structlog
+from faststream.redis import RedisBroker
+
+from lite_bootstrap import (
+    FastAPIBootstrapper,
+    FastAPIConfig,
+    FastStreamBootstrapper,
+    FastStreamConfig,
+    FreeBootstrapper,
+    FreeConfig,
+    LitestarBootstrapper,
+    LitestarConfig,
+    TeardownError,
+)
+from lite_bootstrap.bootstrappers.base import BaseBootstrapper
+from lite_bootstrap.instruments.logging_instrument import LoggingConfig, LoggingInstrument
+from lite_bootstrap.instruments.sentry_instrument import SentryConfig, SentryInstrument
+from tests.conftest import SentryTestTransport
+
+
+class RecordingFilter(logging.Filter):
+    """Records every LogRecord it sees and lets it through unchanged."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen: list[logging.LogRecord] = []
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        self.seen.append(record)
+        return True
+
+
+class DemotingFilter(logging.Filter):
+    """Demotes records whose message contains ``needle`` from ERROR to WARNING."""
+
+    def __init__(self, needle: str) -> None:
+        super().__init__()
+        self.needle = needle
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno == logging.ERROR and self.needle in record.getMessage():
+            record.levelno = logging.WARNING
+            record.levelname = "WARNING"
+        return True
+
+
+class SuppressingFilter(logging.Filter):
+    def __init__(self, needle: str) -> None:
+        super().__init__()
+        self.needle = needle
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return self.needle not in record.getMessage()
+
+
+@pytest.fixture
+def rendered_lines(capsys: pytest.CaptureFixture[str]) -> typing.Callable[[], list[dict[str, typing.Any]]]:
+    def read() -> list[dict[str, typing.Any]]:
+        return [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+
+    return read
+
+
+@pytest.fixture
+def sentry_config(sentry_mock: SentryTestTransport) -> SentryConfig:
+    return SentryConfig(
+        sentry_dsn="https://testdsn@localhost/1",
+        sentry_additional_params={"transport": sentry_mock},
+    )
+
+
+def test_default_config_attaches_no_filters() -> None:
+    """A config that does not ask for filters leaves every logger's filter list untouched."""
+    package_logger = logging.getLogger("default_compat.package")
+    filters_before = list(package_logger.filters)
+    instrument = LoggingInstrument(bootstrap_config=LoggingConfig(logging_buffer_capacity=0))
+    try:
+        instrument.bootstrap()
+        assert package_logger.filters == filters_before
+        assert instrument._attached_filters == []  # noqa: SLF001
+    finally:
+        instrument.teardown()
+
+
+def test_filter_receives_records_from_its_exact_logger() -> None:
+    record_filter = RecordingFilter()
+    instrument = LoggingInstrument(
+        bootstrap_config=LoggingConfig(
+            logging_buffer_capacity=0,
+            logging_record_filters={"exact_match.package.child": (record_filter,)},
+        ),
+    )
+    try:
+        instrument.bootstrap()
+        logging.getLogger("exact_match.package.child").error("child speaking")
+    finally:
+        instrument.teardown()
+
+    assert [record.getMessage() for record in record_filter.seen] == ["child speaking"]
+
+
+def test_filter_on_parent_logger_does_not_see_child_records() -> None:
+    """INVARIANT: a filter registered for one logger name sees only that logger's own records.
+
+    `logging.Logger.handle` consults `self.filters` and then walks *ancestors' handlers*, never
+    ancestors' filters, so a filter on `package` is dead weight for anything `package.child` emits.
+    Reading `logging_record_filters` as a prefix map is the mistake this pins: a user who writes
+    `{"aiokafka": (...)}` expecting to catch `aiokafka.consumer.group_coordinator` gets silence,
+    and silence is indistinguishable from a filter that ran and declined to match.
+    """
+    parent_filter = RecordingFilter()
+    instrument = LoggingInstrument(
+        bootstrap_config=LoggingConfig(
+            logging_buffer_capacity=0,
+            logging_record_filters={"no_inheritance.package": (parent_filter,)},
+        ),
+    )
+    try:
+        instrument.bootstrap()
+        logging.getLogger("no_inheritance.package.child").error("from the child")
+        logging.getLogger("no_inheritance.package").error("from the parent")
+    finally:
+        instrument.teardown()
+
+    assert [record.getMessage() for record in parent_filter.seen] == ["from the parent"]
+
+
+def test_filter_demotes_level_before_handlers_render_it(
+    rendered_lines: typing.Callable[[], list[dict[str, typing.Any]]],
+) -> None:
+    observed: list[tuple[int, str]] = []
+
+    class ObservingFilter(logging.Filter):
+        def filter(self, record: logging.LogRecord) -> bool:
+            observed.append((record.levelno, record.levelname))
+            return True
+
+    instrument = LoggingInstrument(
+        bootstrap_config=LoggingConfig(
+            logging_buffer_capacity=0,
+            logging_record_filters={
+                "demotion.target": (DemotingFilter("expected failure"), ObservingFilter()),
+            },
+        ),
+    )
+    try:
+        instrument.bootstrap()
+        logging.getLogger("demotion.target").error("expected failure, retrying")
+    finally:
+        instrument.teardown()
+
+    assert observed == [(logging.WARNING, "WARNING")]
+    assert [(line["event"], line["level"]) for line in rendered_lines()] == [("expected failure, retrying", "warning")]
+
+
+def test_demoted_record_creates_no_sentry_issue_event(
+    sentry_config: SentryConfig, sentry_mock: SentryTestTransport
+) -> None:
+    """INVARIANT: a filter demoting a record below Sentry's event level keeps it out of Sentry.
+
+    Sentry's `LoggingIntegration` patches `logging.Logger.callHandlers`, which `Logger.handle`
+    reaches only after `self.filter(record)` returns truthy — so a logger filter is upstream of
+    Sentry whatever order the bootstrapper installs the two instruments in. Moving this seam to a
+    structlog processor or a root *handler* filter is what breaks it: both run downstream of the
+    patched `callHandlers`, and the issue is already created by the time they see the record.
+    """
+    logging_instrument = LoggingInstrument(
+        bootstrap_config=LoggingConfig(
+            logging_buffer_capacity=0,
+            logging_record_filters={"sentry_demotion.target": (DemotingFilter("expected failure"),)},
+        ),
+    )
+    sentry_instrument = SentryInstrument(bootstrap_config=sentry_config)
+    try:
+        logging_instrument.bootstrap()
+        sentry_instrument.bootstrap()
+
+        target_logger = logging.getLogger("sentry_demotion.target")
+        target_logger.error("expected failure, retrying")
+        assert sentry_mock.mock_envelopes == []
+
+        target_logger.error("a connection reset")
+        assert len(sentry_mock.mock_envelopes) == 1
+    finally:
+        sentry_instrument.teardown()
+        logging_instrument.teardown()
+
+
+def test_suppressing_filter_keeps_record_from_stream_and_sentry(
+    sentry_config: SentryConfig,
+    sentry_mock: SentryTestTransport,
+    rendered_lines: typing.Callable[[], list[dict[str, typing.Any]]],
+) -> None:
+    logging_instrument = LoggingInstrument(
+        bootstrap_config=LoggingConfig(
+            logging_buffer_capacity=0,
+            logging_record_filters={"suppression.target": (SuppressingFilter("drop me"),)},
+        ),
+    )
+    sentry_instrument = SentryInstrument(bootstrap_config=sentry_config)
+    try:
+        logging_instrument.bootstrap()
+        sentry_instrument.bootstrap()
+        logging.getLogger("suppression.target").error("drop me entirely")
+    finally:
+        sentry_instrument.teardown()
+        logging_instrument.teardown()
+
+    assert rendered_lines() == []
+    assert sentry_mock.mock_envelopes == []
+
+
+def test_non_matching_record_renders_identically_with_and_without_filters(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    timestamper = structlog.processors.TimeStamper(fmt="iso")
+
+    def render_untouched(record_filters: dict[str, tuple[logging.Filter, ...]]) -> dict[str, typing.Any]:
+        instrument = LoggingInstrument(
+            bootstrap_config=LoggingConfig(
+                logging_buffer_capacity=0,
+                logging_time_stamper=timestamper,
+                logging_record_filters=record_filters,
+            ),
+        )
+        try:
+            instrument.bootstrap()
+            logging.getLogger("untouched.target").error("an unrelated failure")
+        finally:
+            instrument.teardown()
+        rendered: dict[str, typing.Any] = json.loads(capsys.readouterr().out)
+        del rendered["timestamp"]
+        return rendered
+
+    assert render_untouched({"untouched.target": (SuppressingFilter("drop me"),)}) == render_untouched({})
+
+
+def test_teardown_removes_only_the_filters_it_attached() -> None:
+    preexisting_filter = RecordingFilter()
+    configured_filter = RecordingFilter()
+    target_logger = logging.getLogger("teardown_isolation.target")
+    target_logger.addFilter(preexisting_filter)
+
+    instrument = LoggingInstrument(
+        bootstrap_config=LoggingConfig(
+            logging_buffer_capacity=0,
+            logging_record_filters={"teardown_isolation.target": (configured_filter,)},
+        ),
+    )
+    try:
+        instrument.bootstrap()
+        assert target_logger.filters == [preexisting_filter, configured_filter]
+
+        instrument.teardown()
+
+        assert target_logger.filters == [preexisting_filter]
+        assert instrument._attached_filters == []  # noqa: SLF001
+    finally:
+        target_logger.removeFilter(preexisting_filter)
+
+
+def test_teardown_removes_filters_even_when_a_handler_close_fails() -> None:
+    configured_filter = RecordingFilter()
+    target_logger = logging.getLogger("teardown_despite_error.target")
+
+    class ExplodingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            """Never called: this handler exists only to fail on close."""
+
+        def close(self) -> None:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+    instrument = LoggingInstrument(
+        bootstrap_config=LoggingConfig(
+            logging_buffer_capacity=0,
+            logging_record_filters={"teardown_despite_error.target": (configured_filter,)},
+        ),
+    )
+    instrument.bootstrap()
+    exploding_handler = ExplodingHandler()
+    logging.getLogger().addHandler(exploding_handler)
+
+    with pytest.raises(TeardownError):
+        instrument.teardown()
+
+    assert target_logger.filters == []
+    assert instrument._attached_filters == []  # noqa: SLF001
+
+
+def test_bootstrap_teardown_bootstrap_attaches_each_filter_once() -> None:
+    configured_filter = RecordingFilter()
+    target_logger = logging.getLogger("filter_lifecycle.target")
+    instrument = LoggingInstrument(
+        bootstrap_config=LoggingConfig(
+            logging_buffer_capacity=0,
+            logging_record_filters={"filter_lifecycle.target": (configured_filter,)},
+        ),
+    )
+    try:
+        instrument.bootstrap()
+        instrument.teardown()
+        instrument.bootstrap()
+
+        assert target_logger.filters == [configured_filter]
+        target_logger.error("once through")
+        assert len(configured_filter.seen) == 1
+    finally:
+        instrument.teardown()
+
+    assert target_logger.filters == []
+
+
+BootstrapperBuilder = typing.Callable[
+    [dict[str, tuple[logging.Filter, ...]]],
+    BaseBootstrapper[typing.Any],
+]
+
+
+def _build_free_bootstrapper(record_filters: dict[str, tuple[logging.Filter, ...]]) -> FreeBootstrapper:
+    return FreeBootstrapper(
+        bootstrap_config=FreeConfig(logging_buffer_capacity=0, logging_record_filters=record_filters),
+    )
+
+
+def _build_fastapi_bootstrapper(record_filters: dict[str, tuple[logging.Filter, ...]]) -> FastAPIBootstrapper:
+    return FastAPIBootstrapper(
+        bootstrap_config=FastAPIConfig(logging_buffer_capacity=0, logging_record_filters=record_filters),
+    )
+
+
+def _build_faststream_bootstrapper(record_filters: dict[str, tuple[logging.Filter, ...]]) -> FastStreamBootstrapper:
+    return FastStreamBootstrapper(
+        bootstrap_config=FastStreamConfig(
+            logging_buffer_capacity=0,
+            logging_record_filters=record_filters,
+            application=faststream.asgi.AsgiFastStream(RedisBroker()),
+        ),
+    )
+
+
+def _build_litestar_bootstrapper(record_filters: dict[str, tuple[logging.Filter, ...]]) -> LitestarBootstrapper:
+    return LitestarBootstrapper(
+        bootstrap_config=LitestarConfig(logging_buffer_capacity=0, logging_record_filters=record_filters),
+    )
+
+
+@pytest.mark.parametrize(
+    ("framework", "build_bootstrapper"),
+    [
+        ("free", _build_free_bootstrapper),
+        ("fastapi", _build_fastapi_bootstrapper),
+        ("faststream", _build_faststream_bootstrapper),
+        ("litestar", _build_litestar_bootstrapper),
+    ],
+)
+def test_every_bootstrapper_installs_configured_filters(
+    framework: str, build_bootstrapper: BootstrapperBuilder
+) -> None:
+    configured_filter = RecordingFilter()
+    logger_name = f"bootstrapper_filters.{framework}"
+    target_logger = logging.getLogger(logger_name)
+
+    bootstrapper = build_bootstrapper({logger_name: (configured_filter,)})
+    bootstrapper.bootstrap()
+    try:
+        target_logger.error("through the bootstrapper")
+    finally:
+        bootstrapper.teardown()
+
+    assert [record.getMessage() for record in configured_filter.seen] == ["through the bootstrapper"]
+    assert target_logger.filters == []

--- a/tests/instruments/test_logging_record_filters.py
+++ b/tests/instruments/test_logging_record_filters.py
@@ -1,15 +1,19 @@
 import json
 import logging
+import re
 import typing
 
 import faststream.asgi
 import pytest
 import structlog
+from fastmcp import FastMCP
 from faststream.redis import RedisBroker
 
 from lite_bootstrap import (
     FastAPIBootstrapper,
     FastAPIConfig,
+    FastMcpBootstrapper,
+    FastMcpConfig,
     FastStreamBootstrapper,
     FastStreamConfig,
     FreeBootstrapper,
@@ -75,17 +79,21 @@ def sentry_config(sentry_mock: SentryTestTransport) -> SentryConfig:
     )
 
 
-def test_default_config_attaches_no_filters() -> None:
-    """A config that does not ask for filters leaves every logger's filter list untouched."""
+def test_default_config_attaches_no_filters(
+    rendered_lines: typing.Callable[[], list[dict[str, typing.Any]]],
+) -> None:
+    """A config that does not ask for filters leaves loggers and rendered records untouched."""
     package_logger = logging.getLogger("default_compat.package")
     filters_before = list(package_logger.filters)
     instrument = LoggingInstrument(bootstrap_config=LoggingConfig(logging_buffer_capacity=0))
     try:
         instrument.bootstrap()
+        package_logger.error("nothing filtered here")
         assert package_logger.filters == filters_before
-        assert instrument._attached_filters == []  # noqa: SLF001
     finally:
         instrument.teardown()
+
+    assert [(line["event"], line["level"]) for line in rendered_lines()] == [("nothing filtered here", "error")]
 
 
 def test_filter_receives_records_from_its_exact_logger() -> None:
@@ -110,9 +118,9 @@ def test_filter_on_parent_logger_does_not_see_child_records() -> None:
 
     `logging.Logger.handle` consults `self.filters` and then walks *ancestors' handlers*, never
     ancestors' filters, so a filter on `package` is dead weight for anything `package.child` emits.
-    Reading `logging_record_filters` as a prefix map is the mistake this pins: a user who writes
-    `{"aiokafka": (...)}` expecting to catch `aiokafka.consumer.group_coordinator` gets silence,
-    and silence is indistinguishable from a filter that ran and declined to match.
+    Reading `logging_record_filters` as a prefix map is the mistake this pins: a user who names the
+    top-level package expecting to catch the submodule that actually logs gets silence, and silence
+    is indistinguishable from a filter that ran and declined to match.
     """
     parent_filter = RecordingFilter()
     instrument = LoggingInstrument(
@@ -131,44 +139,55 @@ def test_filter_on_parent_logger_does_not_see_child_records() -> None:
     assert [record.getMessage() for record in parent_filter.seen] == ["from the parent"]
 
 
+class CapturingHandler(logging.Handler):
+    """A downstream handler: root reaches it through ``callHandlers``, after logger filters ran."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
 def test_filter_demotes_level_before_handlers_render_it(
     rendered_lines: typing.Callable[[], list[dict[str, typing.Any]]],
 ) -> None:
-    observed: list[tuple[int, str]] = []
-
-    class ObservingFilter(logging.Filter):
-        def filter(self, record: logging.LogRecord) -> bool:
-            observed.append((record.levelno, record.levelname))
-            return True
-
     instrument = LoggingInstrument(
         bootstrap_config=LoggingConfig(
             logging_buffer_capacity=0,
-            logging_record_filters={
-                "demotion.target": (DemotingFilter("expected failure"), ObservingFilter()),
-            },
+            logging_record_filters={"demotion.target": (DemotingFilter("expected failure"),)},
         ),
     )
+    downstream_handler = CapturingHandler()
     try:
         instrument.bootstrap()
+        logging.getLogger().addHandler(downstream_handler)
         logging.getLogger("demotion.target").error("expected failure, retrying")
     finally:
         instrument.teardown()
 
-    assert observed == [(logging.WARNING, "WARNING")]
+    assert [(record.levelno, record.levelname) for record in downstream_handler.records] == [
+        (logging.WARNING, "WARNING")
+    ]
     assert [(line["event"], line["level"]) for line in rendered_lines()] == [("expected failure, retrying", "warning")]
 
 
+@pytest.mark.parametrize("sentry_first", [False, True])
 def test_demoted_record_creates_no_sentry_issue_event(
-    sentry_config: SentryConfig, sentry_mock: SentryTestTransport
+    sentry_config: SentryConfig, sentry_mock: SentryTestTransport, sentry_first: bool
 ) -> None:
     """INVARIANT: a filter demoting a record below Sentry's event level keeps it out of Sentry.
 
     Sentry's `LoggingIntegration` patches `logging.Logger.callHandlers`, which `Logger.handle`
     reaches only after `self.filter(record)` returns truthy — so a logger filter is upstream of
-    Sentry whatever order the bootstrapper installs the two instruments in. Moving this seam to a
-    structlog processor or a root *handler* filter is what breaks it: both run downstream of the
-    patched `callHandlers`, and the issue is already created by the time they see the record.
+    Sentry whichever instrument bootstraps first. That independence is load-bearing rather than
+    incidental: only `FreeBootstrapper` lists `LoggingInstrument` before `SentryInstrument`; the
+    FastAPI, Litestar, FastStream and FastMCP bootstrappers all install Sentry first.
+
+    Moving this seam to a structlog processor or a root *handler* filter is what breaks it: both
+    run downstream of the patched `callHandlers`, and the issue is already created by the time
+    they see the record.
     """
     logging_instrument = LoggingInstrument(
         bootstrap_config=LoggingConfig(
@@ -178,8 +197,12 @@ def test_demoted_record_creates_no_sentry_issue_event(
     )
     sentry_instrument = SentryInstrument(bootstrap_config=sentry_config)
     try:
-        logging_instrument.bootstrap()
-        sentry_instrument.bootstrap()
+        if sentry_first:
+            sentry_instrument.bootstrap()
+            logging_instrument.bootstrap()
+        else:
+            logging_instrument.bootstrap()
+            sentry_instrument.bootstrap()
 
         target_logger = logging.getLogger("sentry_demotion.target")
         target_logger.error("expected failure, retrying")
@@ -221,7 +244,7 @@ def test_non_matching_record_renders_identically_with_and_without_filters(
 ) -> None:
     timestamper = structlog.processors.TimeStamper(fmt="iso")
 
-    def render_untouched(record_filters: dict[str, tuple[logging.Filter, ...]]) -> dict[str, typing.Any]:
+    def render_untouched(record_filters: dict[str, tuple[logging.Filter, ...]]) -> str:
         instrument = LoggingInstrument(
             bootstrap_config=LoggingConfig(
                 logging_buffer_capacity=0,
@@ -234,9 +257,8 @@ def test_non_matching_record_renders_identically_with_and_without_filters(
             logging.getLogger("untouched.target").error("an unrelated failure")
         finally:
             instrument.teardown()
-        rendered: dict[str, typing.Any] = json.loads(capsys.readouterr().out)
-        del rendered["timestamp"]
-        return rendered
+        # The timestamp is the one nondeterministic field; everything else must match byte for byte.
+        return re.sub(r'"timestamp":"[^"]*"', "", capsys.readouterr().out)
 
     assert render_untouched({"untouched.target": (SuppressingFilter("drop me"),)}) == render_untouched({})
 
@@ -291,7 +313,6 @@ def test_teardown_removes_filters_even_when_a_handler_close_fails() -> None:
         instrument.teardown()
 
     assert target_logger.filters == []
-    assert instrument._attached_filters == []  # noqa: SLF001
 
 
 def test_bootstrap_teardown_bootstrap_attaches_each_filter_once() -> None:
@@ -351,6 +372,16 @@ def _build_litestar_bootstrapper(record_filters: dict[str, tuple[logging.Filter,
     )
 
 
+def _build_fastmcp_bootstrapper(record_filters: dict[str, tuple[logging.Filter, ...]]) -> FastMcpBootstrapper:
+    return FastMcpBootstrapper(
+        bootstrap_config=FastMcpConfig(
+            logging_buffer_capacity=0,
+            logging_record_filters=record_filters,
+            application=FastMCP[typing.Any](name="microservice"),
+        ),
+    )
+
+
 @pytest.mark.parametrize(
     ("framework", "build_bootstrapper"),
     [
@@ -358,6 +389,7 @@ def _build_litestar_bootstrapper(record_filters: dict[str, tuple[logging.Filter,
         ("fastapi", _build_fastapi_bootstrapper),
         ("faststream", _build_faststream_bootstrapper),
         ("litestar", _build_litestar_bootstrapper),
+        ("fastmcp", _build_fastmcp_bootstrapper),
     ],
 )
 def test_every_bootstrapper_installs_configured_filters(


### PR DESCRIPTION
## What

Adds `logging_record_filters` to `LoggingConfig`: a map of exact standard-library logger name to
`logging.Filter` instances, attached during `LoggingInstrument.bootstrap()` and removed during
`teardown()`. Every framework config inherits it, so no per-framework interface is needed.

```python
FreeConfig(
    logging_record_filters={
        "some_library.internal.worker": (ExpectedThirdPartyFailureFilter(),),
    },
)
```

A filter may leave the record alone, rewrite it (`levelno` + `levelname`), or return `False` to drop
it. Default is empty, so existing behaviour is unchanged and no new runtime dependency is added.

## Why a logger filter, and not a processor

`lite-bootstrap` already has `logging_extra_processors` and the `skip_sentry` field, but both act on
rendered structlog data — too late to change what Sentry's logging integration captured from a
*foreign* `LogRecord`. A `logging.Filter` on the logger runs inside `Logger.handle`, before
`callHandlers`, which is exactly where Sentry's `LoggingIntegration` patches in. That is the only
seam that reliably sees a third-party record before both the root handlers and Sentry.

## A correction to the issue's rationale

The spec claimed the existing instrument order already installs logging before Sentry. That holds
only for `FreeBootstrapper` — FastAPI, Litestar, FastStream and FastMCP all list `SentryInstrument`
first. The requirement is still met, but because of the `Logger.handle` → `callHandlers` sequence
above, not because of instrument ordering. `test_demoted_record_creates_no_sentry_issue_event` is
parametrized over both bootstrap orders rather than trusting the list.

## Unplanned fix included

`LitestarLoggingInstrument` overrode `bootstrap()` wholesale, reimplementing the base's steps
verbatim. Any step the base gained was therefore silently skipped for Litestar users, and filter
attachment was the first such step. It now overrides `_configure_structlog_loggers` instead. Step
order is unchanged; every logging subclass now reaches the base sequence.

## Vocabulary

`CONTEXT.md` gains a **Record filter** entry. The project already had two competing senses of
"filter" — a handler filter and `structlog.stdlib.filter_by_level` — and the distinction between a
record filter and a processor is the whole point of the feature.

## Testing

New `tests/instruments/test_logging_record_filters.py` covers all ten acceptance cases, including two
invariants: a filter on a parent logger does not see a child's records, and a demoted record stays
out of Sentry under either bootstrap order.

Suite: 260 passed, 100% coverage, `ruff` + `ty` clean, `mkdocs build --strict` clean.

Three mutations were used to confirm the suite is not passing vacuously: skipping attachment fails 13
tests, skipping detachment fails 8, and clobbering a logger's whole filter list instead of removing
only this instrument's pairs fails the teardown-isolation test alone.

## Docs

`docs/introduction/configuration.md` gains a section with a generic (non-Kafka) example, and spells
out the two standard-library properties users get wrong: the logger name must be exact (a filter on
`package` never sees `package.child`), and `""` is the root logger — which likewise only sees records
logged through root itself, not records propagating up to it.
