### PR TITLE
Rename the instrument protocol to match the configured/ready split

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,8 +35,9 @@ several inputs `is_configured` reads; most instruments have no enabled flag at a
 A *bootstrapper* is ready when its framework package is importable — `is_ready()`, checked once in
 `__init__`, raising `BootstrapperNotReadyError` when false. It is about the environment, never about
 the config, and it is a different question from whether an instrument is **configured**.
-_Avoid_: configured, for this sense. (Instruments carry a `not_ready_message` that is really the
-not-configured reason; the attribute name predates the split and the two senses still meet there.)
+_Avoid_: configured, for this sense. The attribute names follow the split: a bootstrapper carries
+`not_ready_message`, an instrument carries `not_configured_reason`. An instrument written against
+the old `not_ready_message` still works — `BaseInstrument.__init_subclass__` forwards it.
 
 **Skipped**:
 An instrument the bootstrapper decided not to instantiate. Two paths, deliberately different

--- a/docs/introduction/configuration.md
+++ b/docs/introduction/configuration.md
@@ -238,9 +238,9 @@ Additional params:
 
 When a bootstrapper is constructed, each registered instrument is checked twice:
 
-1. **`is_configured(config)`** (classmethod, runs before instantiation) — returns False if the user's config indicates this instrument shouldn't run (e.g. `sentry_dsn` empty, `logging_enabled=False`, `pyroscope_endpoint` empty). When False, the instrument is **silently skipped** and recorded in `bootstrapper.skipped_instruments: list[tuple[type, str]]` — each entry is the instrument class plus its `not_ready_message`.
+1. **`is_configured(config)`** (classmethod, runs before instantiation) — returns False if the user's config indicates this instrument shouldn't run (e.g. `sentry_dsn` empty, `logging_enabled=False`, `pyroscope_endpoint` empty). When False, the instrument is **silently skipped** and recorded in `bootstrapper.skipped_instruments: list[tuple[type, str]]` — each entry is the instrument class plus its `not_configured_reason`.
 
-2. **`check_dependencies()`** — runs only if `is_configured()` returned True. If the instrument's optional package is missing, an `InstrumentDependencyMissingWarning` is emitted. This is a real "configured but dependency missing" deployment surprise.
+2. **`dependencies_installed()`** — runs only if `is_configured()` returned True. If the instrument's optional package is missing, an `InstrumentDependencyMissingWarning` is emitted. This is a real "configured but dependency missing" deployment surprise.
 
 After the loop, the bootstrapper emits one INFO-level summary log listing configured + skipped instruments. Default Python logging suppresses INFO; opt in via `logging.basicConfig(level=logging.INFO)`.
 

--- a/lite_bootstrap/bootstrappers/base.py
+++ b/lite_bootstrap/bootstrappers/base.py
@@ -21,6 +21,7 @@ InstrumentT = typing.TypeVar("InstrumentT", bound=BaseInstrument)
 
 class BaseBootstrapper(abc.ABC, typing.Generic[ApplicationT]):
     instruments_types: typing.ClassVar[list[type[BaseInstrument]]]
+    not_ready_message: typing.ClassVar[str]
     instruments: list[BaseInstrument]
     skipped_instruments: list[tuple[type[BaseInstrument], str]]
     bootstrap_config: BaseConfig
@@ -85,10 +86,10 @@ class BaseBootstrapper(abc.ABC, typing.Generic[ApplicationT]):
             # missing-optional-dep doesn't fail in a dataclass default_factory before we
             # can decide the user opted out.
             if not instrument_type.is_configured(self.bootstrap_config):
-                self.skipped_instruments.append((instrument_type, instrument_type.not_ready_message))
+                self.skipped_instruments.append((instrument_type, instrument_type.not_configured_reason))
                 continue
             # Dep-missing for a CONFIGURED instrument is a genuine deployment surprise.
-            if not instrument_type.check_dependencies():
+            if not instrument_type.dependencies_installed():
                 warnings.warn(
                     instrument_type.missing_dependency_message,
                     category=InstrumentDependencyMissingWarning,
@@ -104,10 +105,6 @@ class BaseBootstrapper(abc.ABC, typing.Generic[ApplicationT]):
 
         if logger.isEnabledFor(logging.INFO):
             logger.info(self.build_summary())
-
-    @property
-    @abc.abstractmethod
-    def not_ready_message(self) -> str: ...
 
     @abc.abstractmethod
     def _prepare_application(self) -> ApplicationT: ...

--- a/lite_bootstrap/bootstrappers/fastapi_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/fastapi_bootstrapper.py
@@ -72,12 +72,13 @@ class FastAPIConfig(
         elif self.application_kwargs:
             warnings.warn("application_kwargs must be used without application", stacklevel=2)
 
-
-def _narrow_app(config: "FastAPIConfig") -> "fastapi.FastAPI":
-    if isinstance(config.application, UnsetType):
-        msg = "FastAPIConfig.application is UNSET; __post_init__ did not run"
-        raise TypeError(msg)
-    return config.application
+    @property
+    def app(self) -> "fastapi.FastAPI":
+        """The application narrowed past the UNSET sentinel that ``__post_init__`` has replaced."""
+        if isinstance(self.application, UnsetType):
+            msg = "FastAPIConfig.application is UNSET; __post_init__ did not run"
+            raise TypeError(msg)
+        return self.application
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -85,16 +86,7 @@ class FastAPICorsInstrument(CorsInstrument):
     bootstrap_config: FastAPIConfig
 
     def bootstrap(self) -> None:
-        _narrow_app(self.bootstrap_config).add_middleware(
-            CORSMiddleware,
-            allow_origins=self.bootstrap_config.cors_allowed_origins,
-            allow_methods=self.bootstrap_config.cors_allowed_methods,
-            allow_headers=self.bootstrap_config.cors_allowed_headers,
-            allow_credentials=self.bootstrap_config.cors_allowed_credentials,
-            allow_origin_regex=self.bootstrap_config.cors_allowed_origin_regex,
-            expose_headers=self.bootstrap_config.cors_exposed_headers,
-            max_age=self.bootstrap_config.cors_max_age,
-        )
+        self.bootstrap_config.app.add_middleware(CORSMiddleware, **self.cors_kwargs)
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -114,7 +106,7 @@ class FastAPIHealthChecksInstrument(HealthChecksInstrument):
         return fastapi_router
 
     def bootstrap(self) -> None:
-        _narrow_app(self.bootstrap_config).include_router(self.build_fastapi_health_check_router())
+        self.bootstrap_config.app.include_router(self.build_fastapi_health_check_router())
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -124,13 +116,13 @@ class FastAPIOpenTelemetryInstrument(OpenTelemetryInstrument):
     def bootstrap(self) -> None:
         super().bootstrap()
         FastAPIInstrumentor.instrument_app(
-            app=_narrow_app(self.bootstrap_config),
+            app=self.bootstrap_config.app,
             tracer_provider=get_tracer_provider(),
             excluded_urls=",".join(self._build_excluded_urls()),
         )
 
     def teardown(self) -> None:
-        FastAPIInstrumentor.uninstrument_app(_narrow_app(self.bootstrap_config))
+        FastAPIInstrumentor.uninstrument_app(self.bootstrap_config.app)
         super().teardown()
 
 
@@ -140,11 +132,11 @@ class FastAPIPrometheusInstrument(PrometheusInstrument):
     missing_dependency_message = "prometheus_fastapi_instrumentator is not installed"
 
     @staticmethod
-    def check_dependencies() -> bool:
+    def dependencies_installed() -> bool:
         return import_checker.is_prometheus_fastapi_instrumentator_installed
 
     def bootstrap(self) -> None:
-        application = _narrow_app(self.bootstrap_config)
+        application = self.bootstrap_config.app
         Instrumentator(**self.bootstrap_config.prometheus_instrumentator_params).instrument(
             application,
             **self.bootstrap_config.prometheus_instrument_params,
@@ -161,7 +153,7 @@ class FastAPISwaggerInstrument(SwaggerInstrument):
     bootstrap_config: FastAPIConfig
 
     def bootstrap(self) -> None:
-        application = _narrow_app(self.bootstrap_config)
+        application = self.bootstrap_config.app
         if self.bootstrap_config.swagger_path != application.docs_url:
             warnings.warn(
                 f"swagger_path differs from docs_url, {application.docs_url} will be used for docs path",
@@ -196,7 +188,7 @@ class FastAPIBootstrapper(BaseBootstrapper["fastapi.FastAPI"]):
 
     def __init__(self, bootstrap_config: FastAPIConfig) -> None:
         super().__init__(bootstrap_config)
-        application = _narrow_app(self.bootstrap_config)
+        application = self.bootstrap_config.app
         self._attach_teardown_once(application, lambda: self._wrap_lifespan(application))
 
     def _wrap_lifespan(self, application: "fastapi.FastAPI") -> None:
@@ -210,4 +202,4 @@ class FastAPIBootstrapper(BaseBootstrapper["fastapi.FastAPI"]):
         return import_checker.is_fastapi_installed
 
     def _prepare_application(self) -> "fastapi.FastAPI":
-        return _narrow_app(self.bootstrap_config)
+        return self.bootstrap_config.app

--- a/lite_bootstrap/bootstrappers/fastmcp_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/fastmcp_bootstrapper.py
@@ -105,7 +105,7 @@ class FastMcpPrometheusInstrument(PrometheusInstrument):
     missing_dependency_message = "prometheus_client is not installed"
 
     @staticmethod
-    def check_dependencies() -> bool:
+    def dependencies_installed() -> bool:
         return import_checker.is_prometheus_client_installed
 
     def bootstrap(self) -> None:

--- a/lite_bootstrap/bootstrappers/faststream_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/faststream_bootstrapper.py
@@ -147,7 +147,7 @@ class FastStreamLoggingInstrument(LoggingInstrument):
 @dataclasses.dataclass(kw_only=True)
 class FastStreamOpenTelemetryInstrument(OpenTelemetryInstrument):
     bootstrap_config: FastStreamConfig
-    not_ready_message = OpenTelemetryInstrument.not_ready_message + " or opentelemetry_middleware_cls is empty"
+    not_configured_reason = OpenTelemetryInstrument.not_configured_reason + " or opentelemetry_middleware_cls is empty"
 
     @classmethod
     def is_configured(cls, bootstrap_config: "FastStreamConfig") -> bool:  # ty: ignore[invalid-method-override]
@@ -168,7 +168,7 @@ def _make_collector_registry() -> "prometheus_client.CollectorRegistry":
 class FastStreamPrometheusInstrument(PrometheusInstrument):
     bootstrap_config: FastStreamConfig
     collector_registry: "prometheus_client.CollectorRegistry" = dataclasses.field(init=False)
-    not_ready_message = PrometheusInstrument.not_ready_message + " or prometheus_middleware_cls is missing"
+    not_configured_reason = PrometheusInstrument.not_configured_reason + " or prometheus_middleware_cls is missing"
     missing_dependency_message = "prometheus_client is not installed"
 
     def __post_init__(self) -> None:
@@ -180,7 +180,7 @@ class FastStreamPrometheusInstrument(PrometheusInstrument):
         return super().is_configured(bootstrap_config) and bool(bootstrap_config.prometheus_middleware_cls)
 
     @staticmethod
-    def check_dependencies() -> bool:
+    def dependencies_installed() -> bool:
         return import_checker.is_prometheus_client_installed
 
     def bootstrap(self) -> None:

--- a/lite_bootstrap/bootstrappers/litestar_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/litestar_bootstrapper.py
@@ -43,7 +43,7 @@ if import_checker.is_litestar_installed:
 if import_checker.is_litestar_installed and import_checker.is_prometheus_client_installed:
     # litestar.plugins.prometheus imports prometheus_client, which the `litestar`
     # extra does not install (only `litestar-metrics` does). Used only inside
-    # LitestarPrometheusInstrument.bootstrap(), gated by check_dependencies() ->
+    # LitestarPrometheusInstrument.bootstrap(), gated by dependencies_installed() ->
     # is_prometheus_client_installed, so this guard matches the usage.
     from litestar.plugins.prometheus import PrometheusConfig, PrometheusController
 
@@ -162,15 +162,7 @@ class LitestarCorsInstrument(CorsInstrument):
     bootstrap_config: LitestarConfig
 
     def bootstrap(self) -> None:
-        self.bootstrap_config.application_config.cors_config = CORSConfig(
-            allow_origins=self.bootstrap_config.cors_allowed_origins,
-            allow_methods=self.bootstrap_config.cors_allowed_methods,  # ty: ignore[invalid-argument-type]
-            allow_headers=self.bootstrap_config.cors_allowed_headers,
-            allow_credentials=self.bootstrap_config.cors_allowed_credentials,
-            allow_origin_regex=self.bootstrap_config.cors_allowed_origin_regex,
-            expose_headers=self.bootstrap_config.cors_exposed_headers,
-            max_age=self.bootstrap_config.cors_max_age,
-        )
+        self.bootstrap_config.application_config.cors_config = CORSConfig(**self.cors_kwargs)
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -267,7 +259,7 @@ class LitestarPrometheusInstrument(PrometheusInstrument):
     missing_dependency_message = "prometheus_client is not installed"
 
     @staticmethod
-    def check_dependencies() -> bool:
+    def dependencies_installed() -> bool:
         return import_checker.is_prometheus_client_installed
 
     def bootstrap(self) -> None:
@@ -293,7 +285,7 @@ class LitestarPrometheusInstrument(PrometheusInstrument):
 @dataclasses.dataclass(kw_only=True)
 class LitestarSwaggerInstrument(SwaggerInstrument):
     bootstrap_config: LitestarConfig
-    not_ready_message = "swagger_path is empty or not valid"
+    not_configured_reason = "swagger_path is empty or not valid"
 
     @classmethod
     def is_configured(cls, bootstrap_config: "LitestarConfig") -> bool:  # ty: ignore[invalid-method-override]

--- a/lite_bootstrap/instruments/base.py
+++ b/lite_bootstrap/instruments/base.py
@@ -51,7 +51,8 @@ class BaseInstrument(typing.Generic[ConfigT]):
     missing_dependency_message = ""
 
     def __init_subclass__(cls, **kwargs: object) -> None:
-        super().__init_subclass__(**kwargs)
+        # @dataclass(slots=True) replaces the class object, breaking bare super().
+        super(BaseInstrument, cls).__init_subclass__(**kwargs)
         for legacy_name, current_name in _RENAMED_ATTRIBUTES.items():
             if legacy_name in cls.__dict__ and current_name not in cls.__dict__:
                 setattr(cls, current_name, cls.__dict__[legacy_name])

--- a/lite_bootstrap/instruments/base.py
+++ b/lite_bootstrap/instruments/base.py
@@ -37,11 +37,24 @@ class BaseConfig:
 ConfigT = typing.TypeVar("ConfigT", bound=BaseConfig)
 
 
+# Legacy name -> current name; __init_subclass__ forwards an out-of-tree instrument's old spelling.
+_RENAMED_ATTRIBUTES: typing.Final = {
+    "not_ready_message": "not_configured_reason",
+    "check_dependencies": "dependencies_installed",
+}
+
+
 @dataclasses.dataclass(kw_only=True, slots=True)
 class BaseInstrument(typing.Generic[ConfigT]):
     bootstrap_config: ConfigT
-    not_ready_message = ""
+    not_configured_reason = ""
     missing_dependency_message = ""
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        for legacy_name, current_name in _RENAMED_ATTRIBUTES.items():
+            if legacy_name in cls.__dict__ and current_name not in cls.__dict__:
+                setattr(cls, current_name, cls.__dict__[legacy_name])
 
     def bootstrap(self) -> None: ...
 
@@ -53,5 +66,6 @@ class BaseInstrument(typing.Generic[ConfigT]):
         return True
 
     @staticmethod
-    def check_dependencies() -> bool:
+    def dependencies_installed() -> bool:
+        """Return True if this instrument's optional package is importable. Default: nothing to import."""
         return True

--- a/lite_bootstrap/instruments/cors_instrument.py
+++ b/lite_bootstrap/instruments/cors_instrument.py
@@ -34,8 +34,22 @@ class CorsConfig(BaseConfig):
 
 @dataclasses.dataclass(kw_only=True, slots=True)
 class CorsInstrument(BaseInstrument[CorsConfig]):
-    not_ready_message = "cors_allowed_origins or cors_allowed_origin_regex must be provided"
+    not_configured_reason = "cors_allowed_origins or cors_allowed_origin_regex must be provided"
 
     @classmethod
     def is_configured(cls, bootstrap_config: "CorsConfig") -> bool:
         return bool(bootstrap_config.cors_allowed_origins) or bool(bootstrap_config.cors_allowed_origin_regex)
+
+    @property
+    def cors_kwargs(self) -> dict[str, typing.Any]:
+        """The CORS settings under the keyword names Starlette's CORSMiddleware and Litestar's CORSConfig share."""
+        config = self.bootstrap_config
+        return {
+            "allow_origins": config.cors_allowed_origins,
+            "allow_methods": config.cors_allowed_methods,
+            "allow_headers": config.cors_allowed_headers,
+            "allow_credentials": config.cors_allowed_credentials,
+            "allow_origin_regex": config.cors_allowed_origin_regex,
+            "expose_headers": config.cors_exposed_headers,
+            "max_age": config.cors_max_age,
+        }

--- a/lite_bootstrap/instruments/healthchecks_instrument.py
+++ b/lite_bootstrap/instruments/healthchecks_instrument.py
@@ -28,7 +28,7 @@ class HealthChecksConfig(BaseConfig):
 
 @dataclasses.dataclass(kw_only=True, slots=True)
 class HealthChecksInstrument(BaseInstrument[HealthChecksConfig]):
-    not_ready_message = "health_checks_enabled is False"
+    not_configured_reason = "health_checks_enabled is False"
 
     @classmethod
     def is_configured(cls, bootstrap_config: "HealthChecksConfig") -> bool:

--- a/lite_bootstrap/instruments/logging_instrument.py
+++ b/lite_bootstrap/instruments/logging_instrument.py
@@ -80,7 +80,7 @@ class LoggingConfig(BaseConfig):
 
 @dataclasses.dataclass(kw_only=True, slots=True)
 class LoggingInstrument(BaseInstrument[LoggingConfig]):
-    not_ready_message = "logging_enabled is False"
+    not_configured_reason = "logging_enabled is False"
     missing_dependency_message = "structlog is not installed"
     _logger_factory: "MemoryLoggerFactory | None" = dataclasses.field(
         default_factory=lambda: None, init=False, repr=False, compare=False
@@ -107,7 +107,7 @@ class LoggingInstrument(BaseInstrument[LoggingConfig]):
         return bootstrap_config.logging_enabled
 
     @staticmethod
-    def check_dependencies() -> bool:
+    def dependencies_installed() -> bool:
         return import_checker.is_structlog_installed
 
     def _unset_handlers(self) -> None:

--- a/lite_bootstrap/instruments/opentelemetry_instrument.py
+++ b/lite_bootstrap/instruments/opentelemetry_instrument.py
@@ -136,7 +136,7 @@ class OpenTelemetryInstrument(BaseInstrument[OpenTelemetryConfig]):
     ``OpenTelemetryInstrument`` per process; do not bootstrap a second instance.
     """
 
-    not_ready_message = "opentelemetry_endpoint is empty and opentelemetry_log_traces is False"
+    not_configured_reason = "opentelemetry_endpoint is empty and opentelemetry_log_traces is False"
     missing_dependency_message = "opentelemetry-sdk is not installed"
     _tracer_provider: "TracerProvider | None" = dataclasses.field(
         default_factory=lambda: None, init=False, repr=False, compare=False
@@ -150,7 +150,7 @@ class OpenTelemetryInstrument(BaseInstrument[OpenTelemetryConfig]):
         return bool(bootstrap_config.opentelemetry_endpoint or bootstrap_config.opentelemetry_log_traces)
 
     @staticmethod
-    def check_dependencies() -> bool:
+    def dependencies_installed() -> bool:
         # The instrument imports from both the api (opentelemetry.trace/.context) and
         # the sdk (opentelemetry.sdk.*), so it needs both distributions present.
         return import_checker.is_opentelemetry_installed and import_checker.is_opentelemetry_sdk_installed

--- a/lite_bootstrap/instruments/prometheus_instrument.py
+++ b/lite_bootstrap/instruments/prometheus_instrument.py
@@ -14,7 +14,7 @@ class PrometheusConfig(BaseConfig):
 
 @dataclasses.dataclass(kw_only=True, slots=True)
 class PrometheusInstrument(BaseInstrument[PrometheusConfig]):
-    not_ready_message = "prometheus_metrics_path is empty or not valid"
+    not_configured_reason = "prometheus_metrics_path is empty or not valid"
 
     @classmethod
     def is_configured(cls, bootstrap_config: "PrometheusConfig") -> bool:

--- a/lite_bootstrap/instruments/pyroscope_instrument.py
+++ b/lite_bootstrap/instruments/pyroscope_instrument.py
@@ -20,7 +20,7 @@ class PyroscopeConfig(OpenTelemetryServiceFieldsConfig):
 
 @dataclasses.dataclass(kw_only=True, slots=True)
 class PyroscopeInstrument(BaseInstrument[PyroscopeConfig]):
-    not_ready_message = "pyroscope_endpoint is empty"
+    not_configured_reason = "pyroscope_endpoint is empty"
     missing_dependency_message = "pyroscope is not installed"
 
     @classmethod
@@ -28,7 +28,7 @@ class PyroscopeInstrument(BaseInstrument[PyroscopeConfig]):
         return bool(bootstrap_config.pyroscope_endpoint)
 
     @staticmethod
-    def check_dependencies() -> bool:
+    def dependencies_installed() -> bool:
         return import_checker.is_pyroscope_installed
 
     def bootstrap(self) -> None:

--- a/lite_bootstrap/instruments/sentry_instrument.py
+++ b/lite_bootstrap/instruments/sentry_instrument.py
@@ -82,7 +82,7 @@ def wrap_before_send_callbacks(
 
 @dataclasses.dataclass(kw_only=True, slots=True)
 class SentryInstrument(BaseInstrument[SentryConfig]):
-    not_ready_message = "sentry_dsn is empty"
+    not_configured_reason = "sentry_dsn is empty"
     missing_dependency_message = "sentry_sdk is not installed"
 
     @classmethod
@@ -90,7 +90,7 @@ class SentryInstrument(BaseInstrument[SentryConfig]):
         return bool(bootstrap_config.sentry_dsn)
 
     @staticmethod
-    def check_dependencies() -> bool:
+    def dependencies_installed() -> bool:
         return import_checker.is_sentry_installed
 
     def bootstrap(self) -> None:

--- a/tests/instruments/test_base_instrument.py
+++ b/tests/instruments/test_base_instrument.py
@@ -1,0 +1,42 @@
+import dataclasses
+
+from lite_bootstrap.instruments.base import BaseConfig, BaseInstrument
+
+
+def test_base_instrument_defaults() -> None:
+    assert BaseInstrument.not_configured_reason == ""
+    assert BaseInstrument.missing_dependency_message == ""
+    assert BaseInstrument.dependencies_installed() is True
+    assert BaseInstrument.is_configured(BaseConfig()) is True
+
+
+def test_an_instrument_written_against_the_old_attribute_names_still_works() -> None:
+    """INVARIANT: a subclass declaring not_ready_message or check_dependencies keeps both behaviours.
+
+    Both names are part of the instrument protocol documented in `docs/introduction/configuration.md`,
+    so an out-of-tree instrument may define either. What breaks it is renaming them without the
+    forwarding in `BaseInstrument.__init_subclass__`: the bootstrapper would read the inherited empty
+    `not_configured_reason` and report no skip reason, and — far worse — it would call the inherited
+    `dependencies_installed`, which answers True, and construct an instrument whose optional package
+    is absent.
+    """
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class LegacyInstrument(BaseInstrument[BaseConfig]):
+        not_ready_message = "legacy reason"
+
+        @staticmethod
+        def check_dependencies() -> bool:
+            return False
+
+    assert LegacyInstrument.not_configured_reason == "legacy reason"
+    assert LegacyInstrument.dependencies_installed() is False
+
+
+def test_a_subclass_declaring_both_names_keeps_the_current_one() -> None:
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class BothNamesInstrument(BaseInstrument[BaseConfig]):
+        not_ready_message = "legacy reason"
+        not_configured_reason = "current reason"
+
+    assert BothNamesInstrument.not_configured_reason == "current reason"

--- a/tests/instruments/test_cors_instrument.py
+++ b/tests/instruments/test_cors_instrument.py
@@ -7,7 +7,7 @@ from lite_bootstrap.instruments.cors_instrument import CorsConfig, CorsInstrumen
 def test_cors_instrument_not_configured_without_origins_or_regex() -> None:
     config = CorsConfig()
     assert not CorsInstrument.is_configured(config)
-    assert CorsInstrument.not_ready_message == "cors_allowed_origins or cors_allowed_origin_regex must be provided"
+    assert CorsInstrument.not_configured_reason == "cors_allowed_origins or cors_allowed_origin_regex must be provided"
 
 
 def test_cors_instrument_configured_with_origins() -> None:
@@ -40,8 +40,8 @@ def test_cors_instrument_config_defaults() -> None:
     assert config.cors_max_age == expected_max_age
 
 
-def test_cors_check_dependencies() -> None:
-    assert CorsInstrument.check_dependencies() is True
+def test_cors_dependencies_installed() -> None:
+    assert CorsInstrument.dependencies_installed() is True
 
 
 @pytest.mark.parametrize(

--- a/tests/instruments/test_healthchecks_instrument.py
+++ b/tests/instruments/test_healthchecks_instrument.py
@@ -9,7 +9,7 @@ def test_healthchecks_instrument_configured_by_default() -> None:
 def test_healthchecks_instrument_not_configured_when_disabled() -> None:
     config = HealthChecksConfig(health_checks_enabled=False)
     assert not HealthChecksInstrument.is_configured(config)
-    assert HealthChecksInstrument.not_ready_message == "health_checks_enabled is False"
+    assert HealthChecksInstrument.not_configured_reason == "health_checks_enabled is False"
 
 
 def test_healthchecks_render_data_default() -> None:
@@ -41,5 +41,5 @@ def test_healthchecks_config_defaults() -> None:
     assert config.health_checks_include_in_schema is False
 
 
-def test_healthchecks_check_dependencies() -> None:
-    assert HealthChecksInstrument.check_dependencies() is True
+def test_healthchecks_dependencies_installed() -> None:
+    assert HealthChecksInstrument.dependencies_installed() is True

--- a/tests/instruments/test_opentelemetry_instrument.py
+++ b/tests/instruments/test_opentelemetry_instrument.py
@@ -225,7 +225,7 @@ def test_opentelemetry_instrument_survives_missing_sdk() -> None:
         ["lite_bootstrap.instruments.opentelemetry_instrument"],
     ):
         assert import_checker.is_opentelemetry_sdk_installed is False
-        assert OpenTelemetryInstrument.check_dependencies() is False
+        assert OpenTelemetryInstrument.dependencies_installed() is False
 
 
 def test_bootstrap_warns_when_endpoint_set_without_grpc_exporter() -> None:

--- a/tests/instruments/test_prometheus_instrument.py
+++ b/tests/instruments/test_prometheus_instrument.py
@@ -9,7 +9,7 @@ def test_prometheus_instrument_configured_with_default_path() -> None:
 def test_prometheus_instrument_not_configured_with_empty_path() -> None:
     config = PrometheusConfig(prometheus_metrics_path="")
     assert not PrometheusInstrument.is_configured(config)
-    assert PrometheusInstrument.not_ready_message == "prometheus_metrics_path is empty or not valid"
+    assert PrometheusInstrument.not_configured_reason == "prometheus_metrics_path is empty or not valid"
 
 
 def test_prometheus_instrument_not_configured_with_invalid_path() -> None:
@@ -29,5 +29,5 @@ def test_prometheus_config_defaults() -> None:
     assert config.prometheus_metrics_include_in_schema is False
 
 
-def test_prometheus_check_dependencies() -> None:
-    assert PrometheusInstrument.check_dependencies() is True
+def test_prometheus_dependencies_installed() -> None:
+    assert PrometheusInstrument.dependencies_installed() is True

--- a/tests/instruments/test_pyroscope_instrument.py
+++ b/tests/instruments/test_pyroscope_instrument.py
@@ -45,8 +45,8 @@ def test_pyroscope_instrument_is_configured() -> None:
     assert PyroscopeInstrument.is_configured(config)
 
 
-def test_pyroscope_check_dependencies() -> None:
-    assert PyroscopeInstrument.check_dependencies()
+def test_pyroscope_dependencies_installed() -> None:
+    assert PyroscopeInstrument.dependencies_installed()
 
 
 def test_pyroscope_instrument_bootstrap_and_teardown() -> None:

--- a/tests/instruments/test_swagger_instrument.py
+++ b/tests/instruments/test_swagger_instrument.py
@@ -13,5 +13,5 @@ def test_swagger_config_defaults() -> None:
     assert config.swagger_offline_docs is False
 
 
-def test_swagger_check_dependencies() -> None:
-    assert SwaggerInstrument.check_dependencies() is True
+def test_swagger_dependencies_installed() -> None:
+    assert SwaggerInstrument.dependencies_installed() is True

--- a/tests/test_fastapi_bootstrap.py
+++ b/tests/test_fastapi_bootstrap.py
@@ -9,7 +9,6 @@ from starlette import status
 from starlette.testclient import TestClient
 
 from lite_bootstrap import FastAPIBootstrapper, FastAPIConfig
-from lite_bootstrap.bootstrappers.fastapi_bootstrapper import _narrow_app
 from lite_bootstrap.exceptions import ConfigurationError
 from lite_bootstrap.types import UNSET
 from tests.conftest import CustomInstrumentor, SentryTestTransport, emulate_package_missing
@@ -135,13 +134,13 @@ def test_second_fastapi_bootstrapper_on_same_app_warns_not_stacks(fastapi_config
     )
 
 
-def test_narrow_app_raises_when_application_unset() -> None:
+def test_app_property_raises_when_application_unset() -> None:
     # Build a config and forcibly reset application to UNSET to simulate the
-    # invariant violation `_narrow_app` was guarding with an assert.
+    # invariant violation `FastAPIConfig.app` guards.
     config = FastAPIConfig()
     object.__setattr__(config, "application", UNSET)
     with pytest.raises(TypeError, match="application is UNSET"):
-        _narrow_app(config)
+        _ = config.app
 
 
 def test_user_supplied_app_keeps_title_version_debug() -> None:

--- a/tests/test_fastmcp_bootstrap.py
+++ b/tests/test_fastmcp_bootstrap.py
@@ -258,7 +258,7 @@ def test_fastmcp_bootstrapper_with_missing_instrument_dependency(
 
 def test_fastmcp_bootstrap_without_prometheus_client() -> None:
     # Regression guard mirroring the FastStream prometheus-missing test: ensures
-    # FastMcpPrometheusInstrument.check_dependencies() prevents construction-time
+    # FastMcpPrometheusInstrument.dependencies_installed() prevents construction-time
     # failure when prometheus_client is absent.
     with emulate_package_missing_with_module_reload(
         "prometheus_client",

--- a/tests/test_faststream_bootstrap.py
+++ b/tests/test_faststream_bootstrap.py
@@ -165,7 +165,7 @@ def test_faststream_bootstrapper_with_missing_instrument_dependency(broker: Redi
 def test_faststream_bootstrap_without_prometheus_client(broker: RedisBroker) -> None:
     # Regression: issue #87 bug 1 — FastStreamPrometheusInstrument's
     # default_factory called prometheus_client.CollectorRegistry() during
-    # dataclass __init__, raising NameError before check_dependencies() ran.
+    # dataclass __init__, raising NameError before dependencies_installed() ran.
     bootstrap_config = build_faststream_config(broker=broker)
     with emulate_package_missing_with_module_reload(
         "prometheus_client",


### PR DESCRIPTION
Five readability changes from a read-through of the whole library. No behaviour changes; 263 tests at 100% coverage, `ruff` and `ty` clean.

## The rename (the substantive one)

`not_ready_message` carried two meanings eleven lines apart in the same file — `bootstrappers/base.py` read it as *bootstrapper not ready* in `__init__`, and as *instrument not configured* in the instrument-selection loop. That is exactly the split `CONTEXT.md` calls load-bearing, and `CONTEXT.md` had resorted to documenting the collision rather than fixing it ("the attribute name predates the split and the two senses still meet there"). Instruments now carry `not_configured_reason`; bootstrappers keep `not_ready_message`. The vocabulary entry is now a rule instead of an apology.

`check_dependencies()` went with it, to `dependencies_installed()` — it reads as a command at a predicate call site (`if not instrument_type.check_dependencies()`), where its sibling `is_configured` reads as the question it is.

### Why this ships a compat shim

Both names appear in `docs/introduction/configuration.md` as the documented instrument lifecycle, so an out-of-tree instrument may legitimately define either. A bare rename fails quietly in both directions: the bootstrapper would read an inherited empty `not_configured_reason` and report no skip reason, and — the one that matters — it would call the inherited `dependencies_installed`, which answers `True`, and construct an instrument whose optional package is absent.

So `BaseInstrument.__init_subclass__` forwards old spellings to current ones, driven by a `_RENAMED_ATTRIBUTES` dict. It is four lines of machinery in a change whose point is readability, which is a fair thing to push back on — the alternative is a clean break plus a note in the release. An invariant test pins the forwarding, and I confirmed it fails when the forwarding is disabled.

## `BaseBootstrapper.not_ready_message` becomes a `ClassVar[str]`

It was declared `@property @abstractmethod`, and all five bootstrappers satisfy it with a plain string class attribute — none implements it as a property. Declaring it the way it is actually used puts it next to `instruments_types`, which is already an undefaulted `ClassVar` on the same class. `BaseBootstrapper` stays abstract via `_prepare_application` and `is_ready`.

## Two duplications dropped

**`_narrow_app` → `FastAPIConfig.app`.** The helper existed only because `application` is typed `fastapi.FastAPI | UnsetType`, and every FastAPI instrument body opened with `_narrow_app(self.bootstrap_config)` — eight call sites. As a property on the config, the invariant check lives in one place and the call sites are attribute reads. The sentinel itself stays: `__post_init__` needs `swagger_path` and `application_kwargs` to build the default app, which a `default_factory` cannot see.

**One CORS mapping instead of two.** The same seven config fields were mapped by hand in both `FastAPICorsInstrument` and `LitestarCorsInstrument`. Starlette's `CORSMiddleware` and Litestar's `CORSConfig` take *identical* keyword names (verified by introspecting both signatures), so `CorsInstrument.cors_kwargs` serves both and each `bootstrap()` is now one line. This is hoisting shared depth into the base instrument — the thing ADR-0002 says the per-instrument axis is for.

Worth a reviewer's eye: splatting the dict removed a `# ty: ignore[invalid-argument-type]` on Litestar's `allow_methods` (its `Method` literals vs the config's `list[str]`). The suppression meant `ty` was not checking that argument before either, so enforcement is unchanged — but the mismatch is now hidden behind `dict[str, typing.Any]` rather than marked in the source.

## Deliberately not in scope

Inverting to a per-framework adapter axis (ADR-0002) and contributing excluded URLs per instrument (ADR-0004) are already rejected with reasons that still hold. Nothing here reopens them.

Five further findings from the same read-through are not included, and I will file them as issues: `OpenTelemetryInstrument.bootstrap()` is fifty-five lines with an exporter branch that puts the protocol test and the dependency test at the same `elif` level; `self.bootstrap_config.` appears forty-three times in `litestar_bootstrapper.py`; the teardown-error-collection idiom is transcribed three times; `BaseBootstrapper.__init__` does three jobs and sits between two other methods; and `types.BootstrapObjectT` is unreferenced.

One of them is a real defect rather than a readability point: `OpenTelemetryConfig.__post_init__` warns with `stacklevel=2`, but it runs mid-MRO, so a user constructing `FastAPIConfig(opentelemetry_endpoint=...)` gets the insecure-endpoint warning attributed to `lite_bootstrap/instruments/cors_instrument.py:32` instead of their own call site. It is visible in this repo's own pytest warnings summary. That one needs a failing test first.
