### PR TITLE
fix: attribute config warnings to the line that built the config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ paragraph naming **what breaks it** — design rationale, not a report of what t
 
 ## Code style
 
-Three rules that are not visible in the code that follows them:
+Four rules that are not visible in the code that follows them:
 
 - **No `# noqa: PLR2004`.** Extract the magic value to a named local instead:
   `expected_max_age = 600; assert config.cors_max_age == expected_max_age`.
@@ -42,6 +42,10 @@ Three rules that are not visible in the code that follows them:
   re-export both from `__init__.py` if the old name was exported. It is a class assignment, not a
   subclass, so `isinstance` still holds. `FreeBootstrapperConfig`, `OpentelemetryConfig` and
   `IGNORED_STRUCTLOG_ATTRIBUTES` exist for this reason.
+- **A warning raised while a config is being built goes through `warn_at_caller`.** No literal
+  `stacklevel=` reaches the user from a `__post_init__`: the depth is that config's MRO chain plus
+  the `__init__` `dataclasses` generates. Warnings raised outside config construction keep their
+  literal `stacklevel`: their target is the bootstrapper's caller, not the user.
 - **Sentinels on a user's app get a `_lite_bootstrap_` prefix.** Set a direct attribute on the app
   object; never squat in a framework namespace like Starlette's `application.state`. Read it with
   `getattr(target, name, default)` (no SLF violation); write it with `# noqa: SLF001`.

--- a/lite_bootstrap/bootstrappers/fastapi_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/fastapi_bootstrapper.py
@@ -7,6 +7,7 @@ from lite_bootstrap import import_checker
 from lite_bootstrap.bootstrappers.base import BaseBootstrapper
 from lite_bootstrap.exceptions import ConfigurationError
 from lite_bootstrap.helpers.fastapi_helpers import enable_offline_docs
+from lite_bootstrap.helpers.warn import warn_at_caller
 from lite_bootstrap.instruments.cors_instrument import CorsConfig, CorsInstrument
 from lite_bootstrap.instruments.healthchecks_instrument import (
     HealthChecksConfig,
@@ -70,7 +71,7 @@ class FastAPIConfig(
             application.debug = self.service_debug
             application.version = self.service_version
         elif self.application_kwargs:
-            warnings.warn("application_kwargs must be used without application", stacklevel=2)
+            warn_at_caller("application_kwargs must be used without application")
 
     @property
     def app(self) -> "fastapi.FastAPI":

--- a/lite_bootstrap/bootstrappers/litestar_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/litestar_bootstrapper.py
@@ -3,12 +3,12 @@ import dataclasses
 import pathlib
 import re
 import typing
-import warnings
 import weakref
 
 from lite_bootstrap import import_checker
 from lite_bootstrap.bootstrappers.base import BaseBootstrapper
 from lite_bootstrap.helpers.path import is_valid_path
+from lite_bootstrap.helpers.warn import warn_at_caller
 from lite_bootstrap.instruments.cors_instrument import CorsConfig, CorsInstrument
 from lite_bootstrap.instruments.healthchecks_instrument import (
     HealthChecksConfig,
@@ -150,10 +150,9 @@ class LitestarConfig(
         # @dataclass(slots=True) replaces the class object, breaking bare super().
         super(LitestarConfig, self).__post_init__()
         if self.litestar_logging_middleware_config is not None and not self.litestar_logging_middleware_enabled:
-            warnings.warn(
+            warn_at_caller(
                 "litestar_logging_middleware_config is ignored while litestar_logging_middleware_enabled is False; "
-                "set litestar_logging_middleware_enabled=True to turn access logging on.",
-                stacklevel=2,
+                "set litestar_logging_middleware_enabled=True to turn access logging on."
             )
 
 

--- a/lite_bootstrap/helpers/warn.py
+++ b/lite_bootstrap/helpers/warn.py
@@ -1,0 +1,34 @@
+import inspect
+import types
+import typing
+import warnings
+
+
+_DATACLASS_GENERATED_INIT: typing.Final = "<string>"
+_CONSTRUCTION_MODULES: typing.Final = frozenset({__name__.split(".")[0], "dataclasses"})
+
+
+def _is_internal_frame(frame: types.FrameType) -> bool:
+    """Return True while the frame is still part of building a config rather than asking for one.
+
+    `dataclasses` is in the set because `replace()` calls the constructor itself. The `__init__` it
+    generates reports its file as `<string>`, in the defining class's module rather than this one.
+    """
+    if frame.f_code.co_name == "__init__" and frame.f_code.co_filename == _DATACLASS_GENERATED_INIT:
+        return True
+    module_name: str = frame.f_globals.get("__name__", "")
+    return module_name.split(".", maxsplit=1)[0] in _CONSTRUCTION_MODULES
+
+
+def warn_at_caller(message: str) -> None:
+    """Warn at the nearest frame outside the machinery that builds a config.
+
+    Config validation runs inside a `__post_init__` cascade whose depth is the length of that
+    config's MRO chain, so no literal `stacklevel` can name the frame that built the config.
+    """
+    stacklevel = 1
+    frame: types.FrameType | None = inspect.currentframe()
+    while frame is not None and _is_internal_frame(frame):
+        stacklevel += 1
+        frame = frame.f_back
+    warnings.warn(message, stacklevel=stacklevel)

--- a/lite_bootstrap/instruments/opentelemetry_instrument.py
+++ b/lite_bootstrap/instruments/opentelemetry_instrument.py
@@ -7,6 +7,7 @@ import warnings
 
 from lite_bootstrap import import_checker
 from lite_bootstrap.exceptions import InstrumentDependencyMissingWarning, TeardownError
+from lite_bootstrap.helpers.warn import warn_at_caller
 from lite_bootstrap.instruments.base import BaseConfig, BaseInstrument
 
 
@@ -70,10 +71,9 @@ class OpenTelemetryConfig(OpenTelemetryServiceFieldsConfig):
     def __post_init__(self) -> None:
         host = self._parse_remote_insecure_host()
         if host is not None:
-            warnings.warn(
+            warn_at_caller(
                 f"OTLP exporter sending traces unencrypted to non-local host {host!r}; "
-                "set opentelemetry_insecure=False or use a localhost/unix endpoint.",
-                stacklevel=2,
+                "set opentelemetry_insecure=False or use a localhost/unix endpoint."
             )
         super().__post_init__()
 

--- a/tests/test_config_cascade.py
+++ b/tests/test_config_cascade.py
@@ -1,3 +1,7 @@
+import dataclasses
+import typing
+import warnings
+
 import pytest
 
 from lite_bootstrap import (
@@ -8,6 +12,10 @@ from lite_bootstrap import (
     LitestarConfig,
 )
 from lite_bootstrap.instruments.base import BaseConfig
+from lite_bootstrap.instruments.opentelemetry_instrument import OpenTelemetryConfig
+
+
+_REMOTE_INSECURE_ENDPOINT: typing.Final = "collector.example.com:4317"
 
 
 @pytest.mark.parametrize(
@@ -41,3 +49,49 @@ def test_every_framework_config_post_init_cascade_reaches_base_config(
     config_type()
 
     assert reached == [config_type]
+
+
+@pytest.mark.parametrize(
+    "config_type",
+    [FastAPIConfig, FastStreamConfig, FreeConfig, LitestarConfig],
+)
+def test_an_insecure_endpoint_warning_names_the_line_that_built_the_config(
+    config_type: type[OpenTelemetryConfig],
+) -> None:
+    """INVARIANT: a warning raised during config validation is attributed to the user's own frame.
+
+    Every frame between the `warnings.warn` call and the user is lite-bootstrap's: the
+    `__post_init__` links the MRO cascade walks through, and the `__init__` dataclasses generates,
+    which reports itself as `<string>`. None of them is a line the user can edit, so a warning that
+    lands on one is unactionable.
+
+    What breaks it is a literal `stacklevel=`: the distance to the user is not a constant. It is the
+    number of `__post_init__` links below the warning in *that* config's MRO, which differs per
+    framework config and changes whenever a config gains or loses a `__post_init__`. Routing config
+    warnings through `warn_at_caller` is what keeps the number right without anyone maintaining it.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        config_type(opentelemetry_endpoint=_REMOTE_INSECURE_ENDPOINT)
+
+    assert [w.filename for w in caught] == [__file__]
+
+
+@dataclasses.dataclass(kw_only=True, frozen=True)
+class _ServiceConfig(FreeConfig):
+    """A config subclassed the way a service is expected to subclass one, in the service's own module."""
+
+
+def test_a_warning_from_a_subclassed_config_still_names_the_line_that_built_it() -> None:
+    """INVARIANT: subclassing a framework config does not move the warning off the user's line.
+
+    `dataclasses` writes the `__init__` of a subclass into the subclass's own module, so walking up
+    until the frame leaves `lite_bootstrap` stops one frame too early and blames a `<string>` line
+    number in a file that has no such line. Skipping dataclass-generated `__init__` frames, whatever
+    module they claim, is what keeps the attribution on the construction site.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _ServiceConfig(opentelemetry_endpoint=_REMOTE_INSECURE_ENDPOINT)
+
+    assert [w.filename for w in caught] == [__file__]

--- a/tests/test_fastapi_bootstrap.py
+++ b/tests/test_fastapi_bootstrap.py
@@ -96,8 +96,10 @@ def test_fastapi_bootstrapper_docs_url_differ(fastapi_config: FastAPIConfig) -> 
 
 
 def test_fastapi_bootstrapper_apps_and_kwargs_warning(fastapi_config: FastAPIConfig) -> None:
-    with pytest.warns(UserWarning, match="application_kwargs must be used without application"):
+    with pytest.warns(UserWarning, match="application_kwargs must be used without application") as caught:
         dataclasses.replace(fastapi_config, application=fastapi.FastAPI(), application_kwargs={"title": "some title"})
+
+    assert caught[0].filename == __file__
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litestar_bootstrap.py
+++ b/tests/test_litestar_bootstrap.py
@@ -420,8 +420,10 @@ def test_litestar_access_logging_custom_config_replaces_defaults(litestar_config
 
 
 def test_litestar_logging_middleware_config_without_flag_warns(litestar_config: LitestarConfig) -> None:
-    with pytest.warns(UserWarning, match="litestar_logging_middleware_enabled"):
+    with pytest.warns(UserWarning, match="litestar_logging_middleware_enabled") as caught:
         dataclasses.replace(litestar_config, litestar_logging_middleware_config=LoggingMiddlewareConfig())
+
+    assert caught[0].filename == __file__
 
 
 def test_litestar_access_logging_excluded_paths_drops_degenerate_and_duplicates(


### PR DESCRIPTION
Closes #197.

## The bug is wider than the issue reports

#197 reports the OTel insecure-endpoint warning landing on `cors_instrument.py:32`, a `super().__post_init__()` line, and says the other two config warnings "attribute correctly, because those classes are the most derived". Measuring all three shows that second half is false:

```
fastapi-otel:   lite_bootstrap/instruments/cors_instrument.py:32
free-otel:      <string>:41
litestar-otel:  lite_bootstrap/instruments/cors_instrument.py:32
fastapi-own:    <string>:61
```

`stacklevel=2` from a most-derived `__post_init__` lands on the `__init__` that `dataclasses` generates, which reports its filename as `<string>`. The mid-chain case is not the only broken one, it is merely the one that names a real file and therefore looks like a bug.

It gets worse through `dataclasses.replace`, which calls the constructor itself and adds another frame. Both of this repo's own tests for those two warnings go through `replace`, so both were landing on CPython's `dataclasses.py:1813`. No config warning in the package was attributed correctly.

## Why not the option the issue leaned towards

#197 leans towards hoisting cross-cutting validation into a single `BaseConfig._validate()` called once by the most-derived `__post_init__`. That does not fix the attribution. The most-derived `__post_init__` is itself called from the generated `<string>` `__init__`, so a literal `stacklevel` inside `_validate()` is wrong by one for a direct construction and wrong by more through `replace`. It relocates the validation without moving where the warning points.

Consolidating validation may still be worth doing for its own readability reasons. It is a separate change, and it needs this fix underneath it either way.

Also rejected: **skipping only `lite_bootstrap` frames.** Too narrow twice over. It stops at the generated `__init__` of a config the user subclassed, because `dataclasses` writes that `__init__` into the subclass's module, and it stops inside `dataclasses.replace`.

Also rejected: **dropping the `stacklevel` claim and moving the endpoint into the message.** Honest, and it was the fallback, but the message already names the host. What the user cannot recover from the message is which of their config constructions produced it, which is the part a service with several configs needs.

## What this does

`helpers/warn.py::warn_at_caller` walks up from its own frame until it leaves the machinery that builds a config: lite-bootstrap's own frames, `dataclasses`, and any `__init__` whose file is `<string>`. The three config-time warn sites route through it. Call sites get shorter, not longer, since the `stacklevel=` argument goes away.

Warnings raised outside config construction keep their literal `stacklevel`. Their correct target is the bootstrapper's caller, which is a different question; `AGENTS.md` records the split.

## Accepted limits

- **Any `__init__` whose file is `<string>` is skipped**, whoever generated it, so a class built by another code-generating library is stepped over. Matching on `dataclasses`-specific internals instead would be more fragile than the rule it replaces, and being stepped over costs one frame of precision rather than correctness.
- **A wrapper that constructs configs on the user's behalf is blamed instead of the user.** That is the intended reading: the wrapper's author is who can act on the warning.
- **An interpreter without frame introspection gets no walk.** `inspect.currentframe()` returning `None` leaves `stacklevel=1`, so the warning names `helpers/warn.py`. No supported interpreter does this, and the degradation is the old behaviour, not a crash.
- **`warn_at_caller` takes no `category`.** Every current caller wants `UserWarning`; add the parameter when a config-time warning needs a different one.

## Delete this when the floor reaches 3.12

`warnings.warn(..., skip_file_prefixes=...)` expresses this directly and replaces the walk with one argument. The minimum supported version is 3.10 today, so it is not available yet.

## Tests

Both written failing first:

- A parametrized invariant over `FastAPIConfig` / `FastStreamConfig` / `FreeConfig` / `LitestarConfig` asserting the warning's filename is the caller's file. Fails on all four before the change.
- An invariant using a config subclassed in the test module. Verified load-bearing: deleting the `<string>` clause leaves the four-config test green and fails only this one.

The two existing warning tests in `test_fastapi_bootstrap.py` and `test_litestar_bootstrap.py` now also assert attribution. Verified load-bearing: removing `dataclasses` from the skipped modules fails exactly those two.

The repo's own pytest warnings summary now points at `tests/test_config.py:28` instead of `cors_instrument.py:32`.

## Verification

`just lint` (ruff + `ty`) clean, `just docs-build` clean, 268 passed at 100% coverage on 3.10, 3.11, 3.12, 3.13 and 3.14.

## Not included

Six warn sites that fire during `bootstrap()` rather than config construction have the same depth-dependence, `bootstrappers/base.py:93` most clearly. Out of scope here, and still needs an issue.
