### PR TITLE
chore: record issue tracker, triage labels and domain doc layout for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,20 @@ description, and PyPI does not rewrite relative links, so a relative one 404s on
 An invariant is a test whose name is the claim, with a docstring opening `INVARIANT:` and a second
 paragraph naming **what breaks it** — design rationale, not a report of what this one test catches.
 
+## Agent skills
+
+### Issue tracker
+
+GitHub issues on `modern-python/lite-bootstrap`, via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical roles, each label string equal to its name. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
 ## Code style
 
 Three rules that are not visible in the code that follows them:

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,40 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Layout
+
+Single-context, and flat:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-fastmcp-teardown-via-provider-lifespan.md
+│   └── ...
+└── lite_bootstrap/
+```
+
+There is no `CONTEXT-MAP.md` and no per-package `CONTEXT.md` or `docs/adr/`. If you are looking for
+either, the answer is that this repo does not have them.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root. It owns the vocabulary, and `AGENTS.md` requires reading it
+  before naming a concept in code, a test name, or an issue title. The **configured** / **ready**
+  split and the two kinds of **skip** are defined there and are load-bearing throughout.
+- **`docs/adr/`**: read the ADRs that touch the area you are about to work in. They are an internal
+  decision record, excluded from the published docs site, so an ADR is written for contributors
+  rather than users.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0002 (keep the per-instrument axis), but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,9 +52,11 @@ theme:
         icon: material/brightness-4
         name: Switch to system preference
 
-# docs/adr/ is an internal decision record, not user documentation; it is not published.
+# docs/adr/ is an internal decision record and docs/agents/ is agent configuration; neither is user
+# documentation, so neither is published.
 exclude_docs: |
   /adr/
+  /agents/
 
 validation:
   omitted_files: warn


### PR DESCRIPTION
Scaffolds the per-repo configuration the engineering skills expect under `docs/agents/`. Without it those skills have no way to know where issues live, which label strings play the five triage roles, or how the domain docs are laid out, and they abort rather than guess.

## What is recorded

- **Issue tracker**: GitHub issues on `modern-python/lite-bootstrap`, via the `gh` CLI. Settled by the remote, and `AGENTS.md` already said "Real work not scheduled becomes a GitHub issue". The "PRs as a request surface" flag is left off, so external PRs stay out of the triage queue.
- **Triage labels**: the five canonical roles under their default names. Only `wontfix` exists in the repo today; the other four get created when first applied.
- **Domain docs**: `CONTEXT.md` and `docs/adr/` at the root, and nothing else.

## The domain doc file describes this repo, not the generic case

The seed template for `domain.md` documents two layouts, single-context and multi-context, and tells the reader to check for `CONTEXT-MAP.md` and `src/<context>/docs/adr/`. Neither exists here and neither is planned, so all of it is cut. What is left states the actual layout once, names the `configured` / `ready` split as the load-bearing part of `CONTEXT.md`, and says plainly that per-package contexts do not exist so an agent stops looking.

The template's worked example also cited a fictional "ADR-0007 (event-sourced orders)". This repo has a real ADR-0007, about declaring `typing-extensions` in core, so the example now points at a real one instead.

## Two judgement calls

**The `## Agent skills` block goes in `AGENTS.md`, not `CLAUDE.md`.** The scaffolding convention prefers `CLAUDE.md` where it exists. Here it exists but its entire content is one line, `@AGENTS.md`. Writing into a pointer file would split repo guidance across two files for no gain; `AGENTS.md` holds everything else and is reachable from both names.

**`mkdocs.yml` now excludes `/agents/`.** `just docs-build` runs `mkdocs build --strict`, which treats any file under `docs/` that is absent from the nav as a warning and aborts. Adding three files broke the docs build. They are excluded on the same reasoning already written in that file for `/adr/`: not user documentation, so not published. Without this change the docs CI job fails.

## Verification

`just docs-build` clean, `just lint` clean, 263 tests pass. This branch is off `main` and carries no code changes, so it is independent of #200. Both branches touch `AGENTS.md`, so whichever merges second needs a trivial conflict resolution there.
