### PR TITLE
refactor: split OpenTelemetryInstrument.bootstrap() into named steps

### DIFF
--- a/lite_bootstrap/instruments/opentelemetry_instrument.py
+++ b/lite_bootstrap/instruments/opentelemetry_instrument.py
@@ -18,7 +18,12 @@ if import_checker.is_opentelemetry_sdk_installed:
     from opentelemetry.context import Context
     from opentelemetry.sdk import resources
     from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor, TracerProvider
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter, SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export import (
+        BatchSpanProcessor,
+        ConsoleSpanExporter,
+        SimpleSpanProcessor,
+        SpanExporter,
+    )
     from opentelemetry.trace import Span, format_span_id, set_tracer_provider
 
 if import_checker.is_otlp_grpc_exporter_installed:
@@ -166,11 +171,13 @@ class OpenTelemetryInstrument(BaseInstrument[OpenTelemetryConfig]):
                 excluded_urls.add(health_path)
         return excluded_urls
 
-    def bootstrap(self) -> None:
+    def _silence_otel_loggers(self) -> None:
         for logger_name in ("opentelemetry.instrumentation.instrumentor", "opentelemetry.trace"):
             otel_logger = logging.getLogger(logger_name)
             self._prior_logger_disabled[logger_name] = otel_logger.disabled
             otel_logger.disabled = True
+
+    def _build_resource(self) -> "resources.Resource":
         attributes = {
             resources.SERVICE_NAME: self.bootstrap_config.opentelemetry_service_name
             or self.bootstrap_config.service_name,
@@ -179,47 +186,38 @@ class OpenTelemetryInstrument(BaseInstrument[OpenTelemetryConfig]):
             resources.SERVICE_VERSION: self.bootstrap_config.service_version,
             resources.CONTAINER_NAME: self.bootstrap_config.opentelemetry_container_name,
         }
-        resource: typing.Final = resources.Resource.create(
-            attributes={k: v for k, v in attributes.items() if v},
-        )
-        tracer_provider = TracerProvider(resource=resource)
-        set_tracer_provider(tracer_provider)
-        self._tracer_provider = tracer_provider
-        if import_checker.is_pyroscope_installed and getattr(self.bootstrap_config, "pyroscope_endpoint", None):
-            tracer_provider.add_span_processor(PyroscopeSpanProcessor())
-        if self.bootstrap_config.opentelemetry_log_traces:
-            tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter(formatter=_format_span)))
-        if self.bootstrap_config.opentelemetry_endpoint:
-            if self.bootstrap_config.opentelemetry_exporter_protocol == "grpc":
-                if import_checker.is_otlp_grpc_exporter_installed:
-                    tracer_provider.add_span_processor(
-                        BatchSpanProcessor(
-                            OTLPGrpcSpanExporter(
-                                endpoint=self.bootstrap_config.opentelemetry_endpoint,
-                                insecure=self.bootstrap_config.opentelemetry_insecure,
-                            ),
-                        ),
-                    )
-                else:
-                    warnings.warn(
-                        "opentelemetry_endpoint is set but the gRPC OTLP exporter is not installed; "
-                        "spans will not be exported. Install lite-bootstrap[otl].",
-                        category=InstrumentDependencyMissingWarning,
-                        stacklevel=2,
-                    )
-            elif import_checker.is_otlp_http_exporter_installed:
-                tracer_provider.add_span_processor(
-                    BatchSpanProcessor(
-                        OTLPHttpSpanExporter(endpoint=self.bootstrap_config.opentelemetry_endpoint),
-                    ),
-                )
-            else:
+        return resources.Resource.create(attributes={k: v for k, v in attributes.items() if v})
+
+    def _build_span_exporter(self) -> "SpanExporter | None":
+        """Return the OTLP exporter for the configured protocol, or None after warning it is missing.
+
+        Only call this once opentelemetry_endpoint is set: both warnings claim that it is.
+        """
+        # stacklevel counts this frame as well as bootstrap()'s, to land on bootstrap()'s caller.
+        if self.bootstrap_config.opentelemetry_exporter_protocol == "grpc":
+            if not import_checker.is_otlp_grpc_exporter_installed:
                 warnings.warn(
-                    "opentelemetry_endpoint is set but the HTTP OTLP exporter is not installed; "
-                    "spans will not be exported. Install lite-bootstrap[otl-http].",
+                    "opentelemetry_endpoint is set but the gRPC OTLP exporter is not installed; "
+                    "spans will not be exported. Install lite-bootstrap[otl].",
                     category=InstrumentDependencyMissingWarning,
-                    stacklevel=2,
+                    stacklevel=3,
                 )
+                return None
+            return OTLPGrpcSpanExporter(
+                endpoint=self.bootstrap_config.opentelemetry_endpoint,
+                insecure=self.bootstrap_config.opentelemetry_insecure,
+            )
+        if not import_checker.is_otlp_http_exporter_installed:
+            warnings.warn(
+                "opentelemetry_endpoint is set but the HTTP OTLP exporter is not installed; "
+                "spans will not be exported. Install lite-bootstrap[otl-http].",
+                category=InstrumentDependencyMissingWarning,
+                stacklevel=3,
+            )
+            return None
+        return OTLPHttpSpanExporter(endpoint=self.bootstrap_config.opentelemetry_endpoint)
+
+    def _apply_instrumentors(self, tracer_provider: "TracerProvider") -> None:
         for one_instrumentor in self.bootstrap_config.opentelemetry_instrumentors:
             if isinstance(one_instrumentor, InstrumentorWithParams):
                 one_instrumentor.instrumentor.instrument(
@@ -228,6 +226,19 @@ class OpenTelemetryInstrument(BaseInstrument[OpenTelemetryConfig]):
                 )
             else:
                 one_instrumentor.instrument(tracer_provider=tracer_provider)
+
+    def bootstrap(self) -> None:
+        self._silence_otel_loggers()
+        tracer_provider = TracerProvider(resource=self._build_resource())
+        set_tracer_provider(tracer_provider)
+        self._tracer_provider = tracer_provider
+        if import_checker.is_pyroscope_installed and getattr(self.bootstrap_config, "pyroscope_endpoint", None):
+            tracer_provider.add_span_processor(PyroscopeSpanProcessor())
+        if self.bootstrap_config.opentelemetry_log_traces:
+            tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter(formatter=_format_span)))
+        if self.bootstrap_config.opentelemetry_endpoint and (span_exporter := self._build_span_exporter()):
+            tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+        self._apply_instrumentors(tracer_provider)
 
     def teardown(self) -> None:
         errors: list[tuple[str, BaseException]] = []

--- a/tests/instruments/test_opentelemetry_instrument.py
+++ b/tests/instruments/test_opentelemetry_instrument.py
@@ -292,3 +292,37 @@ def test_http_protocol_does_not_emit_insecure_warning() -> None:
             opentelemetry_endpoint="http://remote-collector:4318/v1/traces",
             opentelemetry_exporter_protocol="http",
         )
+
+
+@pytest.mark.parametrize(
+    ("protocol", "endpoint", "flag_name"),
+    [
+        ("grpc", "localhost:4317", "is_otlp_grpc_exporter_installed"),
+        ("http", "http://collector:4318/v1/traces", "is_otlp_http_exporter_installed"),
+    ],
+)
+def test_missing_exporter_warning_points_at_the_caller_of_bootstrap(
+    protocol: typing.Literal["grpc", "http"], endpoint: str, flag_name: str
+) -> None:
+    """INVARIANT: the missing-exporter warning is attributed to the frame that called bootstrap().
+
+    The stacklevel is a literal, so it counts frames that only exist by convention: any helper
+    extracted out of bootstrap() moves the warning one frame deeper, onto lite_bootstrap's own
+    source, and nothing but this test notices. Both transports are pinned because each warns
+    from its own branch and a refactor can reshape one without the other.
+    """
+    instrument = OpenTelemetryInstrument(
+        bootstrap_config=OpenTelemetryConfig(opentelemetry_endpoint=endpoint, opentelemetry_exporter_protocol=protocol)
+    )
+    try:
+        with (
+            patch.object(import_checker, flag_name, False),
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            warnings.simplefilter("always")
+            instrument.bootstrap()
+    finally:
+        instrument.teardown()
+
+    matching = [w for w in caught if issubclass(w.category, InstrumentDependencyMissingWarning)]
+    assert [w.filename for w in matching] == [__file__]


### PR DESCRIPTION
Closes #198.

`bootstrap()` ran ~60 lines doing five separable jobs. Split along the seams the issue named: `_silence_otel_loggers()`, `_build_resource()`, `_build_span_exporter()`, `_apply_instrumentors()`. `bootstrap()` is now eleven lines of named steps.

The exporter selection was the part that actually misled. The two transports did symmetric work but sat at different nesting levels, and the outer `elif` tested a dependency flag rather than the protocol, so the trailing `else` read as the else of the protocol check when it was really the HTTP-exporter-missing branch. `_build_span_exporter()` returns the exporter or `None`, emitting the missing-dependency warning itself, so both transports are branches of the same shape and the call site is one line.

## Two deviations from the issue's sketch

**The endpoint guard stayed in `bootstrap()`.** The proposed call site was:

```python
if exporter := self._build_span_exporter():
```

Both of the helper's warnings open `"opentelemetry_endpoint is set but..."`, which is only true because the caller checked. Entering the helper with no endpoint would warn wrongly, so the guard stays:

```python
if self.bootstrap_config.opentelemetry_endpoint and (span_exporter := self._build_span_exporter()):
```

`and` short-circuits, so reachability is identical to before. The helper's docstring states the precondition.

**`stacklevel` 2 -> 3.** The extraction inserts a frame between `warnings.warn` and `bootstrap()`. Leaving the literal alone would have silently moved the warning onto `bootstrap()` itself. This is the one thing the refactor could break invisibly, so it got a test first: the new invariant fails if the bump is reverted, verified in both directions.

## Behaviour

Unchanged, checked hunk by hunk: same processors in the same order (pyroscope, console, batch), byte-identical warning messages, same categories, same reachability. `teardown()` is untouched per the issue's Note.

## Follow-up filed, not folded in

Reviewing this surfaced that the attribution the `stacklevel` preserves was already wrong before the change, and is wrong in a way no literal can fix — measured:

| bootstrapper | warning attributed to |
| --- | --- |
| `FreeBootstrapper` | `bootstrappers/base.py:127` |
| `FastAPIBootstrapper` | `bootstrappers/fastapi_bootstrapper.py:118` |

Two different depths, neither of them the caller, because `FastAPIOpenTelemetryInstrument.bootstrap()` adds a `super().bootstrap()` frame the free path lacks. This is already tracked as #202, which measures the same two depths and additionally establishes that `base.py:42` and `base.py:93` are correct today and that `helpers/fastapi_helpers.py:28` is out of scope. Not folded in here: it is a behaviour change this issue ruled out, and #202 turns on an open design decision — whether the target is the `bootstrapper.bootstrap()` call or the instrument — with the `AGENTS.md` rule on literal `stacklevel` to be rewritten alongside whatever is chosen.

## Checks

`just lint` and `just test` clean: 270 passed, 100% coverage, `ruff` and `ty` green.
