### PR TITLE
refactor: mechanical readability pass (#199)

### DIFF
--- a/lite_bootstrap/bootstrappers/base.py
+++ b/lite_bootstrap/bootstrappers/base.py
@@ -7,7 +7,7 @@ from lite_bootstrap.exceptions import (
     BootstrapperNotReadyError,
     ConfigurationError,
     InstrumentDependencyMissingWarning,
-    TeardownError,
+    collect_teardown_errors,
 )
 from lite_bootstrap.instruments.base import BaseConfig, BaseInstrument
 from lite_bootstrap.types import ApplicationT
@@ -30,6 +30,52 @@ class BaseBootstrapper(abc.ABC, typing.Generic[ApplicationT]):
     # attached its teardown to the framework's shutdown lifecycle. Prevents a second
     # bootstrapper on the same app from re-attaching. Its accepted limits: ADR-0003.
     _TEARDOWN_MARKER: typing.ClassVar[str] = "_lite_bootstrap_teardown_attached"
+
+    def __init__(self, bootstrap_config: BaseConfig) -> None:
+        self.is_bootstrapped = False
+        # Set when another bootstrapper already owns this application; bootstrap() then refuses.
+        self._attach_skipped = False
+        if not self.is_ready():
+            msg = f"{type(self).__name__} is not ready: {self.not_ready_message}"
+            raise BootstrapperNotReadyError(msg)
+
+        self.bootstrap_config = bootstrap_config
+        self.instruments = []
+        self.skipped_instruments = []
+        self._select_instruments()
+
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(self.build_summary())
+
+    def _select_instruments(self) -> None:
+        """Instantiate every configured instrument type, recording the two kinds of skip.
+
+        Called by ``__init__`` once ``instruments`` and ``skipped_instruments`` exist; it fills
+        both. The signals differ on purpose — see "Skipped" in CONTEXT.md.
+        """
+        for instrument_type in self.instruments_types:
+            # Config-level skip first: silent (no warning). Runs before instantiation so a
+            # missing-optional-dep doesn't fail in a dataclass default_factory before we
+            # can decide the user opted out.
+            if not instrument_type.is_configured(self.bootstrap_config):
+                self.skipped_instruments.append((instrument_type, instrument_type.not_configured_reason))
+                continue
+            # Dep-missing for a CONFIGURED instrument is a genuine deployment surprise.
+            if not instrument_type.dependencies_installed():
+                # stacklevel counts this frame, __init__'s and the subclass __init__'s, to land
+                # on the line that constructed the bootstrapper.
+                warnings.warn(
+                    instrument_type.missing_dependency_message,
+                    category=InstrumentDependencyMissingWarning,
+                    stacklevel=4,
+                )
+                logger.warning(
+                    "instrument %s skipped: %s",
+                    instrument_type.__name__,
+                    instrument_type.missing_dependency_message,
+                )
+                continue
+            self.instruments.append(instrument_type(bootstrap_config=self.bootstrap_config))
 
     def _attach_teardown_once(self, target: object, attach: typing.Callable[[], object]) -> None:
         """Run ``attach`` (which wires ``teardown`` into the framework's shutdown) once per target.
@@ -70,42 +116,6 @@ class BaseBootstrapper(abc.ABC, typing.Generic[ApplicationT]):
             lines.append("    (none)")
         return "\n".join(lines)
 
-    def __init__(self, bootstrap_config: BaseConfig) -> None:
-        self.is_bootstrapped = False
-        # Set when another bootstrapper already owns this application; bootstrap() then refuses.
-        self._attach_skipped = False
-        if not self.is_ready():
-            msg = f"{type(self).__name__} is not ready: {self.not_ready_message}"
-            raise BootstrapperNotReadyError(msg)
-
-        self.bootstrap_config = bootstrap_config
-        self.instruments = []
-        self.skipped_instruments = []
-        for instrument_type in self.instruments_types:
-            # Config-level skip first: silent (no warning). Runs before instantiation so a
-            # missing-optional-dep doesn't fail in a dataclass default_factory before we
-            # can decide the user opted out.
-            if not instrument_type.is_configured(self.bootstrap_config):
-                self.skipped_instruments.append((instrument_type, instrument_type.not_configured_reason))
-                continue
-            # Dep-missing for a CONFIGURED instrument is a genuine deployment surprise.
-            if not instrument_type.dependencies_installed():
-                warnings.warn(
-                    instrument_type.missing_dependency_message,
-                    category=InstrumentDependencyMissingWarning,
-                    stacklevel=3,
-                )
-                logger.warning(
-                    "instrument %s skipped: %s",
-                    instrument_type.__name__,
-                    instrument_type.missing_dependency_message,
-                )
-                continue
-            self.instruments.append(instrument_type(bootstrap_config=self.bootstrap_config))
-
-        if logger.isEnabledFor(logging.INFO):
-            logger.info(self.build_summary())
-
     @abc.abstractmethod
     def _prepare_application(self) -> ApplicationT: ...
 
@@ -131,13 +141,7 @@ class BaseBootstrapper(abc.ABC, typing.Generic[ApplicationT]):
         if not self.is_bootstrapped:
             return
         self.is_bootstrapped = False
-        errors: list[tuple[str, BaseException]] = []
-        for one_instrument in reversed(self.instruments):
-            try:
-                one_instrument.teardown()
-            except Exception as e:  # noqa: BLE001, PERF203
-                name = type(one_instrument).__name__
-                logger.warning("Error tearing down %s: %s", name, e)
-                errors.append((name, e))
-        if errors:
-            raise TeardownError(errors) from errors[0][1]
+        with collect_teardown_errors(logger) as teardown_errors:
+            for one_instrument in reversed(self.instruments):
+                with teardown_errors.capture(type(one_instrument).__name__):
+                    one_instrument.teardown()

--- a/lite_bootstrap/bootstrappers/fastapi_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/fastapi_bootstrapper.py
@@ -137,15 +137,16 @@ class FastAPIPrometheusInstrument(PrometheusInstrument):
         return import_checker.is_prometheus_fastapi_instrumentator_installed
 
     def bootstrap(self) -> None:
-        application = self.bootstrap_config.app
-        Instrumentator(**self.bootstrap_config.prometheus_instrumentator_params).instrument(
+        config = self.bootstrap_config
+        application = config.app
+        Instrumentator(**config.prometheus_instrumentator_params).instrument(
             application,
-            **self.bootstrap_config.prometheus_instrument_params,
+            **config.prometheus_instrument_params,
         ).expose(
             application,
-            endpoint=self.bootstrap_config.prometheus_metrics_path,
-            include_in_schema=self.bootstrap_config.prometheus_metrics_include_in_schema,
-            **self.bootstrap_config.prometheus_expose_params,
+            endpoint=config.prometheus_metrics_path,
+            include_in_schema=config.prometheus_metrics_include_in_schema,
+            **config.prometheus_expose_params,
         )
 
 
@@ -154,14 +155,15 @@ class FastAPISwaggerInstrument(SwaggerInstrument):
     bootstrap_config: FastAPIConfig
 
     def bootstrap(self) -> None:
-        application = self.bootstrap_config.app
-        if self.bootstrap_config.swagger_path != application.docs_url:
+        config = self.bootstrap_config
+        application = config.app
+        if config.swagger_path != application.docs_url:
             warnings.warn(
                 f"swagger_path differs from docs_url, {application.docs_url} will be used for docs path",
                 stacklevel=2,
             )
-        if self.bootstrap_config.swagger_offline_docs:
-            enable_offline_docs(application, static_path=self.bootstrap_config.swagger_static_path)
+        if config.swagger_offline_docs:
+            enable_offline_docs(application, static_path=config.swagger_static_path)
 
 
 class FastAPIBootstrapper(BaseBootstrapper["fastapi.FastAPI"]):

--- a/lite_bootstrap/bootstrappers/fastmcp_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/fastmcp_bootstrapper.py
@@ -89,11 +89,13 @@ class FastMcpHealthChecksInstrument(HealthChecksInstrument):
     bootstrap_config: FastMcpConfig
 
     def bootstrap(self) -> None:
-        @self.bootstrap_config.application.custom_route(
-            self.bootstrap_config.health_checks_path,
+        config = self.bootstrap_config
+
+        @config.application.custom_route(
+            config.health_checks_path,
             methods=["GET"],
             name="health_check",
-            include_in_schema=self.bootstrap_config.health_checks_include_in_schema,
+            include_in_schema=config.health_checks_include_in_schema,
         )
         async def health_check_handler(_: "Request") -> "JSONResponse":
             return JSONResponse(dict(self.render_health_check_data()))
@@ -109,11 +111,13 @@ class FastMcpPrometheusInstrument(PrometheusInstrument):
         return import_checker.is_prometheus_client_installed
 
     def bootstrap(self) -> None:
-        @self.bootstrap_config.application.custom_route(
-            self.bootstrap_config.prometheus_metrics_path,
+        config = self.bootstrap_config
+
+        @config.application.custom_route(
+            config.prometheus_metrics_path,
             methods=["GET"],
             name="metrics",
-            include_in_schema=self.bootstrap_config.prometheus_metrics_include_in_schema,
+            include_in_schema=config.prometheus_metrics_include_in_schema,
         )
         async def metrics_handler(_: "Request") -> "Response":
             return Response(

--- a/lite_bootstrap/bootstrappers/faststream_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/faststream_bootstrapper.py
@@ -85,6 +85,8 @@ class FastStreamHealthChecksInstrument(HealthChecksInstrument):
     bootstrap_config: FastStreamConfig
 
     def bootstrap(self) -> None:
+        config = self.bootstrap_config
+
         @handle_get
         async def check_health(_: object) -> "AsgiResponse":
             return (
@@ -97,23 +99,17 @@ class FastStreamHealthChecksInstrument(HealthChecksInstrument):
                 else AsgiResponse(b"Service is unhealthy", 500, headers={"content-type": "text/plain"})
             )
 
-        if (
-            self.bootstrap_config.opentelemetry_generate_health_check_spans
-            and import_checker.is_opentelemetry_installed
-        ):
-            check_health = tracer.start_as_current_span(f"GET {self.bootstrap_config.health_checks_path}")(
-                check_health,
-            )
+        if config.opentelemetry_generate_health_check_spans and import_checker.is_opentelemetry_installed:
+            check_health = tracer.start_as_current_span(f"GET {config.health_checks_path}")(check_health)
 
-        self.bootstrap_config.application.mount(self.bootstrap_config.health_checks_path, check_health)
+        config.application.mount(config.health_checks_path, check_health)
 
     async def _define_health_status(self) -> bool:
-        if not self.bootstrap_config.application or not self.bootstrap_config.application.broker:
+        config = self.bootstrap_config
+        if not config.application or not config.application.broker:
             return False
 
-        return await self.bootstrap_config.application.broker.ping(
-            timeout=self.bootstrap_config.faststream_health_check_broker_timeout,
-        )
+        return await config.application.broker.ping(timeout=config.faststream_health_check_broker_timeout)
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -154,9 +150,10 @@ class FastStreamOpenTelemetryInstrument(OpenTelemetryInstrument):
         return super().is_configured(bootstrap_config) and bool(bootstrap_config.opentelemetry_middleware_cls)
 
     def bootstrap(self) -> None:
-        if self.bootstrap_config.opentelemetry_middleware_cls and self.bootstrap_config.application.broker:
-            self.bootstrap_config.application.broker.add_middleware(
-                self.bootstrap_config.opentelemetry_middleware_cls(tracer_provider=get_tracer_provider())
+        config = self.bootstrap_config
+        if config.opentelemetry_middleware_cls and config.application.broker:
+            config.application.broker.add_middleware(
+                config.opentelemetry_middleware_cls(tracer_provider=get_tracer_provider())
             )
 
 
@@ -184,13 +181,12 @@ class FastStreamPrometheusInstrument(PrometheusInstrument):
         return import_checker.is_prometheus_client_installed
 
     def bootstrap(self) -> None:
-        self.bootstrap_config.application.mount(
-            self.bootstrap_config.prometheus_metrics_path, prometheus_client.make_asgi_app(self.collector_registry)
+        config = self.bootstrap_config
+        config.application.mount(
+            config.prometheus_metrics_path, prometheus_client.make_asgi_app(self.collector_registry)
         )
-        if self.bootstrap_config.prometheus_middleware_cls and self.bootstrap_config.application.broker:
-            self.bootstrap_config.application.broker.add_middleware(
-                self.bootstrap_config.prometheus_middleware_cls(registry=self.collector_registry)
-            )
+        if config.prometheus_middleware_cls and config.application.broker:
+            config.application.broker.add_middleware(config.prometheus_middleware_cls(registry=self.collector_registry))
 
 
 class FastStreamBootstrapper(BaseBootstrapper["AsgiFastStream"]):

--- a/lite_bootstrap/bootstrappers/litestar_bootstrapper.py
+++ b/lite_bootstrap/bootstrappers/litestar_bootstrapper.py
@@ -190,11 +190,12 @@ class LitestarLoggingInstrument(LoggingInstrument):
 
     def _build_logging_middleware_excluded_paths(self) -> list[str]:
         """Regex-escaped path prefixes for infrastructure routes not worth an access log line."""
+        config = self.bootstrap_config
         candidate_paths: typing.Final = (
-            self.bootstrap_config.swagger_path,
-            self.bootstrap_config.swagger_static_path if self.bootstrap_config.swagger_offline_docs else "",
-            self.bootstrap_config.health_checks_path,
-            self.bootstrap_config.prometheus_metrics_path,
+            config.swagger_path,
+            config.swagger_static_path if config.swagger_offline_docs else "",
+            config.health_checks_path,
+            config.prometheus_metrics_path,
         )
         excluded_paths: list[str] = []
         for candidate_path in candidate_paths:
@@ -262,23 +263,22 @@ class LitestarPrometheusInstrument(PrometheusInstrument):
         return import_checker.is_prometheus_client_installed
 
     def bootstrap(self) -> None:
+        config = self.bootstrap_config
+
         class LitestarPrometheusController(PrometheusController):
-            path = self.bootstrap_config.prometheus_metrics_path
-            include_in_schema = self.bootstrap_config.prometheus_metrics_include_in_schema
+            path = config.prometheus_metrics_path
+            include_in_schema = config.prometheus_metrics_include_in_schema
             openmetrics_format = True
 
         # Merged so prometheus_additional_params can override group_path without a kwarg collision.
         prometheus_params: dict[str, typing.Any] = {
-            "group_path": self.bootstrap_config.prometheus_group_path,
-            **self.bootstrap_config.prometheus_additional_params,
+            "group_path": config.prometheus_group_path,
+            **config.prometheus_additional_params,
         }
-        litestar_prometheus_config = PrometheusConfig(
-            app_name=self.bootstrap_config.service_name,
-            **prometheus_params,
-        )
+        litestar_prometheus_config = PrometheusConfig(app_name=config.service_name, **prometheus_params)
 
-        self.bootstrap_config.application_config.route_handlers.append(LitestarPrometheusController)
-        self.bootstrap_config.application_config.middleware.append(litestar_prometheus_config.middleware)
+        config.application_config.route_handlers.append(LitestarPrometheusController)
+        config.application_config.middleware.append(litestar_prometheus_config.middleware)
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -291,33 +291,30 @@ class LitestarSwaggerInstrument(SwaggerInstrument):
         return bool(bootstrap_config.swagger_path) and is_valid_path(bootstrap_config.swagger_path)
 
     def bootstrap(self) -> None:
+        config = self.bootstrap_config
         render_plugins: typing.Final = (
             (
                 SwaggerRenderPlugin(
-                    js_url=f"{self.bootstrap_config.swagger_static_path}/swagger-ui-bundle.js",
-                    css_url=f"{self.bootstrap_config.swagger_static_path}/swagger-ui.css",
-                    standalone_preset_js_url=(
-                        f"{self.bootstrap_config.swagger_static_path}/swagger-ui-standalone-preset.js"
-                    ),
+                    js_url=f"{config.swagger_static_path}/swagger-ui-bundle.js",
+                    css_url=f"{config.swagger_static_path}/swagger-ui.css",
+                    standalone_preset_js_url=f"{config.swagger_static_path}/swagger-ui-standalone-preset.js",
                 ),
             )
-            if self.bootstrap_config.swagger_offline_docs
+            if config.swagger_offline_docs
             else (SwaggerRenderPlugin(),)
         )
-        self.bootstrap_config.application_config.openapi_config = OpenAPIConfig(
-            path=self.bootstrap_config.swagger_path,
-            title=self.bootstrap_config.service_name,
-            version=self.bootstrap_config.service_version,
-            description=self.bootstrap_config.service_description,
+        config.application_config.openapi_config = OpenAPIConfig(
+            path=config.swagger_path,
+            title=config.service_name,
+            version=config.service_version,
+            description=config.service_description,
             render_plugins=render_plugins,
-            **self.bootstrap_config.swagger_extra_params,
+            **config.swagger_extra_params,
         )
-        if self.bootstrap_config.swagger_offline_docs:
+        if config.swagger_offline_docs:
             static_dir_path = pathlib.Path(__file__).parent.parent / "static/litestar_docs"
-            self.bootstrap_config.application_config.route_handlers.append(
-                create_static_files_router(
-                    path=self.bootstrap_config.swagger_static_path, directories=[static_dir_path]
-                )
+            config.application_config.route_handlers.append(
+                create_static_files_router(path=config.swagger_static_path, directories=[static_dir_path])
             )
 
 

--- a/lite_bootstrap/exceptions.py
+++ b/lite_bootstrap/exceptions.py
@@ -1,3 +1,8 @@
+import contextlib
+import logging
+import typing
+
+
 class LiteBootstrapError(RuntimeError):
     """Base class for all lite-bootstrap errors."""
 
@@ -29,3 +34,35 @@ class InstrumentSkippedWarning(UserWarning):
 
 class InstrumentDependencyMissingWarning(InstrumentSkippedWarning):
     """Emitted when an instrument is skipped because its optional dependency is not installed."""
+
+
+class TeardownErrorCollector:
+    """Accumulates teardown failures so the steps after a failing one still run."""
+
+    def __init__(self, logger: logging.Logger | None = None) -> None:
+        self.errors: list[tuple[str, BaseException]] = []
+        self._logger = logger
+
+    @contextlib.contextmanager
+    def capture(self, name: str) -> typing.Iterator[None]:
+        """Record an ``Exception`` raised by one teardown step under ``name`` and continue."""
+        try:
+            yield
+        except Exception as e:  # noqa: BLE001
+            if self._logger is not None:
+                self._logger.warning("Error tearing down %s: %s", name, e)
+            self.errors.append((name, e))
+
+
+@contextlib.contextmanager
+def collect_teardown_errors(logger: logging.Logger | None = None) -> typing.Iterator[TeardownErrorCollector]:
+    """Collect the failures of individual teardown steps and raise them together.
+
+    Raises :class:`TeardownError` on leaving the block if any ``capture()`` recorded
+    something, chained from the first failure. A ``BaseException`` escaping the block
+    propagates as-is and nothing is raised on top of it.
+    """
+    collector = TeardownErrorCollector(logger)
+    yield collector
+    if collector.errors:
+        raise TeardownError(collector.errors) from collector.errors[0][1]

--- a/lite_bootstrap/instruments/logging_instrument.py
+++ b/lite_bootstrap/instruments/logging_instrument.py
@@ -4,7 +4,7 @@ import sys
 import typing
 
 from lite_bootstrap import import_checker
-from lite_bootstrap.exceptions import TeardownError
+from lite_bootstrap.exceptions import collect_teardown_errors
 from lite_bootstrap.instruments.base import BaseConfig, BaseInstrument
 from lite_bootstrap.instruments.logging_factory import (
     AddressProtocol,
@@ -128,11 +128,12 @@ class LoggingInstrument(BaseInstrument[LoggingConfig]):
     def memory_logger_factory(self) -> "MemoryLoggerFactory":
         cached: MemoryLoggerFactory | None = self._logger_factory
         if cached is None:
+            config = self.bootstrap_config
             cached = MemoryLoggerFactory(
                 config=_MemoryLoggerFactoryConfig(
-                    logging_buffer_capacity=self.bootstrap_config.logging_buffer_capacity,
-                    logging_flush_level=self.bootstrap_config.logging_flush_level,
-                    logging_log_level=self.bootstrap_config.logging_log_level,
+                    logging_buffer_capacity=config.logging_buffer_capacity,
+                    logging_flush_level=config.logging_flush_level,
+                    logging_log_level=config.logging_log_level,
                 ),
             )
             self._logger_factory = cached
@@ -199,23 +200,18 @@ class LoggingInstrument(BaseInstrument[LoggingConfig]):
         """
         structlog.reset_defaults()
         root_logger = logging.getLogger()
-        errors: list[tuple[str, BaseException]] = []
-        try:
-            for h in root_logger.handlers[:]:
-                root_logger.removeHandler(h)
-                try:
-                    h.close()
-                except Exception as e:  # noqa: BLE001
-                    errors.append((type(h).__name__, e))
-            root_logger.setLevel(logging.WARNING)
-        finally:
-            self._detach_record_filters()
-            if self._logger_factory is not None:
-                try:
-                    self._logger_factory.close_handlers()
-                except Exception as e:  # noqa: BLE001
-                    errors.append(("MemoryLoggerFactory", e))
-                finally:
-                    self._logger_factory = None
-        if errors:
-            raise TeardownError(errors) from errors[0][1]
+        with collect_teardown_errors() as teardown_errors:
+            try:
+                for h in root_logger.handlers[:]:
+                    root_logger.removeHandler(h)
+                    with teardown_errors.capture(type(h).__name__):
+                        h.close()
+                root_logger.setLevel(logging.WARNING)
+            finally:
+                self._detach_record_filters()
+                if self._logger_factory is not None:
+                    try:
+                        with teardown_errors.capture("MemoryLoggerFactory"):
+                            self._logger_factory.close_handlers()
+                    finally:
+                        self._logger_factory = None

--- a/lite_bootstrap/instruments/opentelemetry_instrument.py
+++ b/lite_bootstrap/instruments/opentelemetry_instrument.py
@@ -6,7 +6,7 @@ import urllib.parse
 import warnings
 
 from lite_bootstrap import import_checker
-from lite_bootstrap.exceptions import InstrumentDependencyMissingWarning, TeardownError
+from lite_bootstrap.exceptions import InstrumentDependencyMissingWarning, collect_teardown_errors
 from lite_bootstrap.helpers.warn import warn_at_caller
 from lite_bootstrap.instruments.base import BaseConfig, BaseInstrument
 
@@ -161,12 +161,13 @@ class OpenTelemetryInstrument(BaseInstrument[OpenTelemetryConfig]):
         return import_checker.is_opentelemetry_installed and import_checker.is_opentelemetry_sdk_installed
 
     def _build_excluded_urls(self) -> set[str]:
-        excluded_urls: set[str] = set(self.bootstrap_config.opentelemetry_excluded_urls)
-        prometheus_path = getattr(self.bootstrap_config, "prometheus_metrics_path", None)
+        config = self.bootstrap_config
+        excluded_urls: set[str] = set(config.opentelemetry_excluded_urls)
+        prometheus_path = getattr(config, "prometheus_metrics_path", None)
         if prometheus_path:
             excluded_urls.add(prometheus_path)
-        if not self.bootstrap_config.opentelemetry_generate_health_check_spans:
-            health_path = getattr(self.bootstrap_config, "health_checks_path", None)
+        if not config.opentelemetry_generate_health_check_spans:
+            health_path = getattr(config, "health_checks_path", None)
             if health_path:
                 excluded_urls.add(health_path)
         return excluded_urls
@@ -178,13 +179,13 @@ class OpenTelemetryInstrument(BaseInstrument[OpenTelemetryConfig]):
             otel_logger.disabled = True
 
     def _build_resource(self) -> "resources.Resource":
+        config = self.bootstrap_config
         attributes = {
-            resources.SERVICE_NAME: self.bootstrap_config.opentelemetry_service_name
-            or self.bootstrap_config.service_name,
+            resources.SERVICE_NAME: config.opentelemetry_service_name or config.service_name,
             resources.TELEMETRY_SDK_LANGUAGE: "python",
-            resources.SERVICE_NAMESPACE: self.bootstrap_config.opentelemetry_namespace,
-            resources.SERVICE_VERSION: self.bootstrap_config.service_version,
-            resources.CONTAINER_NAME: self.bootstrap_config.opentelemetry_container_name,
+            resources.SERVICE_NAMESPACE: config.opentelemetry_namespace,
+            resources.SERVICE_VERSION: config.service_version,
+            resources.CONTAINER_NAME: config.opentelemetry_container_name,
         }
         return resources.Resource.create(attributes={k: v for k, v in attributes.items() if v})
 
@@ -193,8 +194,9 @@ class OpenTelemetryInstrument(BaseInstrument[OpenTelemetryConfig]):
 
         Only call this once opentelemetry_endpoint is set: both warnings claim that it is.
         """
+        config = self.bootstrap_config
         # stacklevel counts this frame as well as bootstrap()'s, to land on bootstrap()'s caller.
-        if self.bootstrap_config.opentelemetry_exporter_protocol == "grpc":
+        if config.opentelemetry_exporter_protocol == "grpc":
             if not import_checker.is_otlp_grpc_exporter_installed:
                 warnings.warn(
                     "opentelemetry_endpoint is set but the gRPC OTLP exporter is not installed; "
@@ -204,8 +206,8 @@ class OpenTelemetryInstrument(BaseInstrument[OpenTelemetryConfig]):
                 )
                 return None
             return OTLPGrpcSpanExporter(
-                endpoint=self.bootstrap_config.opentelemetry_endpoint,
-                insecure=self.bootstrap_config.opentelemetry_insecure,
+                endpoint=config.opentelemetry_endpoint,
+                insecure=config.opentelemetry_insecure,
             )
         if not import_checker.is_otlp_http_exporter_installed:
             warnings.warn(
@@ -215,7 +217,7 @@ class OpenTelemetryInstrument(BaseInstrument[OpenTelemetryConfig]):
                 stacklevel=3,
             )
             return None
-        return OTLPHttpSpanExporter(endpoint=self.bootstrap_config.opentelemetry_endpoint)
+        return OTLPHttpSpanExporter(endpoint=config.opentelemetry_endpoint)
 
     def _apply_instrumentors(self, tracer_provider: "TracerProvider") -> None:
         for one_instrumentor in self.bootstrap_config.opentelemetry_instrumentors:
@@ -228,40 +230,36 @@ class OpenTelemetryInstrument(BaseInstrument[OpenTelemetryConfig]):
                 one_instrumentor.instrument(tracer_provider=tracer_provider)
 
     def bootstrap(self) -> None:
+        config = self.bootstrap_config
         self._silence_otel_loggers()
         tracer_provider = TracerProvider(resource=self._build_resource())
         set_tracer_provider(tracer_provider)
         self._tracer_provider = tracer_provider
-        if import_checker.is_pyroscope_installed and getattr(self.bootstrap_config, "pyroscope_endpoint", None):
+        if import_checker.is_pyroscope_installed and getattr(config, "pyroscope_endpoint", None):
             tracer_provider.add_span_processor(PyroscopeSpanProcessor())
-        if self.bootstrap_config.opentelemetry_log_traces:
+        if config.opentelemetry_log_traces:
             tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter(formatter=_format_span)))
-        if self.bootstrap_config.opentelemetry_endpoint and (span_exporter := self._build_span_exporter()):
+        if config.opentelemetry_endpoint and (span_exporter := self._build_span_exporter()):
             tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
         self._apply_instrumentors(tracer_provider)
 
     def teardown(self) -> None:
-        errors: list[tuple[str, BaseException]] = []
-        for one_instrumentor in self.bootstrap_config.opentelemetry_instrumentors:
-            try:
-                if isinstance(one_instrumentor, InstrumentorWithParams):
-                    one_instrumentor.instrumentor.uninstrument(**one_instrumentor.additional_params)
-                else:
-                    one_instrumentor.uninstrument()
-            except Exception as e:  # noqa: BLE001, PERF203
-                errors.append((type(one_instrumentor).__name__, e))
-        for logger_name, prior in self._prior_logger_disabled.items():
-            logging.getLogger(logger_name).disabled = prior
-        self._prior_logger_disabled.clear()
-        if self._tracer_provider is not None:
-            try:
-                self._tracer_provider.shutdown()
-            except Exception as e:  # noqa: BLE001
-                errors.append(("TracerProvider", e))
-            finally:
-                self._tracer_provider = None
-        if errors:
-            raise TeardownError(errors) from errors[0][1]
+        with collect_teardown_errors() as teardown_errors:
+            for one_instrumentor in self.bootstrap_config.opentelemetry_instrumentors:
+                with teardown_errors.capture(type(one_instrumentor).__name__):
+                    if isinstance(one_instrumentor, InstrumentorWithParams):
+                        one_instrumentor.instrumentor.uninstrument(**one_instrumentor.additional_params)
+                    else:
+                        one_instrumentor.uninstrument()
+            for logger_name, prior in self._prior_logger_disabled.items():
+                logging.getLogger(logger_name).disabled = prior
+            self._prior_logger_disabled.clear()
+            if self._tracer_provider is not None:
+                try:
+                    with teardown_errors.capture("TracerProvider"):
+                        self._tracer_provider.shutdown()
+                finally:
+                    self._tracer_provider = None
 
 
 # Backward-compatible alias preserved for users importing the old (lowercase t) spelling.

--- a/lite_bootstrap/instruments/pyroscope_instrument.py
+++ b/lite_bootstrap/instruments/pyroscope_instrument.py
@@ -32,19 +32,20 @@ class PyroscopeInstrument(BaseInstrument[PyroscopeConfig]):
         return import_checker.is_pyroscope_installed
 
     def bootstrap(self) -> None:
+        config = self.bootstrap_config
         # is_configured() guarantees pyroscope_endpoint is set when called via the
         # bootstrapper. Direct callers bypassing is_configured see an explicit raise.
-        if self.bootstrap_config.pyroscope_endpoint is None:
+        if config.pyroscope_endpoint is None:
             msg = "pyroscope_endpoint is unset; PyroscopeInstrument.is_configured() should have returned False"
             raise RuntimeError(msg)
-        namespace = self.bootstrap_config.opentelemetry_namespace
-        tags = ({"service_namespace": namespace} if namespace else {}) | self.bootstrap_config.pyroscope_tags
+        namespace = config.opentelemetry_namespace
+        tags = ({"service_namespace": namespace} if namespace else {}) | config.pyroscope_tags
         pyroscope.configure(
-            application_name=self.bootstrap_config.opentelemetry_service_name or self.bootstrap_config.service_name,
-            server_address=self.bootstrap_config.pyroscope_endpoint,
-            sample_rate=self.bootstrap_config.pyroscope_sample_rate,
+            application_name=config.opentelemetry_service_name or config.service_name,
+            server_address=config.pyroscope_endpoint,
+            sample_rate=config.pyroscope_sample_rate,
             tags=tags,
-            **self.bootstrap_config.pyroscope_additional_params,
+            **config.pyroscope_additional_params,
         )
 
     def teardown(self) -> None:

--- a/lite_bootstrap/instruments/sentry_instrument.py
+++ b/lite_bootstrap/instruments/sentry_instrument.py
@@ -94,22 +94,21 @@ class SentryInstrument(BaseInstrument[SentryConfig]):
         return import_checker.is_sentry_installed
 
     def bootstrap(self) -> None:
+        config = self.bootstrap_config
         sentry_sdk.init(
-            dsn=self.bootstrap_config.sentry_dsn,
-            sample_rate=self.bootstrap_config.sentry_sample_rate,
-            traces_sample_rate=self.bootstrap_config.sentry_traces_sample_rate,
-            environment=self.bootstrap_config.service_environment,
-            max_breadcrumbs=self.bootstrap_config.sentry_max_breadcrumbs,
-            max_value_length=self.bootstrap_config.sentry_max_value_length,
-            attach_stacktrace=self.bootstrap_config.sentry_attach_stacktrace,
-            integrations=self.bootstrap_config.sentry_integrations,
-            default_integrations=self.bootstrap_config.sentry_default_integrations,
-            before_send=wrap_before_send_callbacks(
-                enrich_sentry_event_from_structlog_log, self.bootstrap_config.sentry_before_send
-            ),
-            **self.bootstrap_config.sentry_additional_params,
+            dsn=config.sentry_dsn,
+            sample_rate=config.sentry_sample_rate,
+            traces_sample_rate=config.sentry_traces_sample_rate,
+            environment=config.service_environment,
+            max_breadcrumbs=config.sentry_max_breadcrumbs,
+            max_value_length=config.sentry_max_value_length,
+            attach_stacktrace=config.sentry_attach_stacktrace,
+            integrations=config.sentry_integrations,
+            default_integrations=config.sentry_default_integrations,
+            before_send=wrap_before_send_callbacks(enrich_sentry_event_from_structlog_log, config.sentry_before_send),
+            **config.sentry_additional_params,
         )
-        tags: dict[str, str] = self.bootstrap_config.sentry_tags or {}
+        tags: dict[str, str] = config.sentry_tags or {}
         sentry_sdk.set_tags(tags)
 
     def teardown(self) -> None:

--- a/lite_bootstrap/types.py
+++ b/lite_bootstrap/types.py
@@ -1,7 +1,6 @@
 import typing
 
 
-BootstrapObjectT = typing.TypeVar("BootstrapObjectT", bound=typing.Any)
 ApplicationT = typing.TypeVar("ApplicationT", bound=typing.Any)
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,56 @@
+import logging
+
+import pytest
+
+from lite_bootstrap.exceptions import TeardownError, TeardownErrorCollector, collect_teardown_errors
+
+
+def _run_teardown(
+    steps: list[tuple[str, BaseException | None]],
+    logger: logging.Logger | None = None,
+) -> TeardownErrorCollector:
+    """Run one ``collect_teardown_errors`` block, capturing each named step's exception (if any)."""
+    with collect_teardown_errors(logger) as teardown_errors:
+        for name, error in steps:
+            with teardown_errors.capture(name):
+                if error is not None:
+                    raise error
+    return teardown_errors
+
+
+def test_collect_teardown_errors_raises_one_teardown_error_after_the_block() -> None:
+    first = RuntimeError("boom-1")
+    second = ValueError("boom-2")
+
+    with pytest.raises(TeardownError) as excinfo:
+        _run_teardown([("First", first), ("Second", second)])
+
+    assert excinfo.value.errors == [("First", first), ("Second", second)]
+    assert excinfo.value.__cause__ is first
+
+
+def test_collect_teardown_errors_is_silent_when_nothing_failed() -> None:
+    assert _run_teardown([("Fine", None)]).errors == []
+
+
+def test_capture_logs_a_warning_when_a_logger_is_given(caplog: pytest.LogCaptureFixture) -> None:
+    test_logger = logging.getLogger("tests.test_exceptions")
+
+    with caplog.at_level(logging.WARNING, logger=test_logger.name), pytest.raises(TeardownError):
+        _run_teardown([("Noisy", RuntimeError("boom"))], logger=test_logger)
+
+    assert [(record.levelno, record.message) for record in caplog.records] == [
+        (logging.WARNING, "Error tearing down Noisy: boom")
+    ]
+
+
+def test_capture_lets_base_exceptions_through() -> None:
+    """INVARIANT: capture() collects an Exception and lets every other BaseException propagate.
+
+    Broadening the ``except`` clause in ``capture`` to ``BaseException`` breaks it: a
+    ``KeyboardInterrupt`` would be swallowed, the remaining teardown steps would run anyway, and
+    the interrupt would surface at the end of the block as a ``TeardownError`` — an uninterruptible
+    teardown that reports the wrong failure.
+    """
+    with pytest.raises(KeyboardInterrupt):
+        _run_teardown([("Interrupted", KeyboardInterrupt())])

--- a/tests/test_free_bootstrap.py
+++ b/tests/test_free_bootstrap.py
@@ -118,6 +118,23 @@ def test_free_bootstrapper_with_missing_instrument_dependency(
         FreeBootstrapper(bootstrap_config=free_bootstrapper_config)
 
 
+def test_missing_dependency_warning_points_at_the_bootstrapper_construction_site(
+    free_bootstrapper_config: FreeConfig,
+) -> None:
+    """INVARIANT: the dep-missing warning is attributed to the line that constructed the bootstrapper.
+
+    The warning is raised several frames below the user — inside instrument selection, under
+    ``BaseBootstrapper.__init__``, under the subclass's own ``__init__`` — and its literal
+    ``stacklevel`` counts every one of them. Adding or removing a frame between the
+    ``warnings.warn`` call and the constructor silently re-points the warning at lite-bootstrap's
+    own source, where it tells the user nothing about which bootstrapper asked for the instrument.
+    """
+    with emulate_package_missing("sentry_sdk"), pytest.warns(InstrumentDependencyMissingWarning) as caught:
+        FreeBootstrapper(bootstrap_config=free_bootstrapper_config)
+
+    assert [one_warning.filename for one_warning in caught] == [__file__]
+
+
 def test_attach_teardown_once_attaches_then_warns_and_skips(free_bootstrapper_config: FreeConfig) -> None:
     bootstrapper = FreeBootstrapper(bootstrap_config=free_bootstrapper_config)
     target = types.SimpleNamespace()


### PR DESCRIPTION
Closes #199.

Four independent cleanups from the same read-through, no behaviour change in any of them.

### 1. `self.bootstrap_config.` as line noise

A `config = self.bootstrap_config` local in every method that uses the prefix more than
twice. The issue named four files; this went repo-wide once the same shape turned up in
`fastmcp_bootstrapper.py` and in the Sentry, Pyroscope and logging instruments — the
Sentry `bootstrap()` alone spent the prefix 12 times. An AST sweep now reports no method
over the threshold. Methods at exactly two uses are left alone, which is where the issue
drew the line.

Plain `config =`, never `config: typing.Final =`: `CorsInstrument.bootstrap()` already
spelled it that way before this change, so the codebase had a convention to match.

### 2. The teardown-error idiom is transcribed three times

One `collect_teardown_errors()` context manager in `exceptions.py`, next to the error it
raises. It yields a collector whose `capture(name)` records one step's failure and lets
teardown continue; the optional `logger` argument carries `base.py`'s per-failure warning,
which the two instruments deliberately do not emit.

Both nested `finally` shapes in `LoggingInstrument.teardown()` are preserved verbatim
rather than folded into `capture()`. `capture()` swallows `Exception`, so the `finally`s
are what still guarantee `_detach_record_filters()` and the factory reset run when a
`BaseException` — a `KeyboardInterrupt` mid-teardown — passes through.

`raise ... from collector.errors[0][1]` still fires outside any `except`, so `__cause__`
is the first failure and `__context__` stays `None`, as in all three originals.

One observable drift worth naming: the teardown warning's `LogRecord.pathname` and
`funcName` now point at `exceptions.py`. Same logger name, same message; nothing asserts
it.

### 3. `BaseBootstrapper` reads out of order

`__init__` moved directly under the class attributes, and its instrument-selection loop
extracted to `_select_instruments()`.

That extraction adds a stack frame, so the `InstrumentDependencyMissingWarning`
`stacklevel` had to go 3 -> 4 to keep landing on the line that constructed the
bootstrapper. The literal now depends on every bootstrapper defining its own `__init__`,
including `FreeBootstrapper`'s pure `super()` pass-through — delete that one-line
delegation and the warning silently re-points at lite-bootstrap's own source. Pinned as an
invariant in `test_free_bootstrap.py`, which fails if that `__init__` goes away.

### 4. `types.BootstrapObjectT` is dead

Deleted. No references in the package, tests, benchmarks or docs. `ApplicationT` in the
same file is live and stays.

## Tests

`tests/test_exceptions.py` is new: the collector's contract is not fully reachable through
the three call sites, and the repo gates on 100% coverage. It covers aggregation and
chaining, the silent path, the logging argument, and an invariant that `capture()` lets
every non-`Exception` `BaseException` through — broadening that `except` would make
teardown uninterruptible.

`ruff format`, `ruff check`, `ty check` clean; 275 tests pass at 100% statement coverage.
Branch coverage is unchanged from `main` at 99.10%, the same 32 partial branches, all of
them module-level `if import_checker.is_X_installed:` guards.