### PR TITLE
feat: declare minimum compatible versions for fastmcp and faststream

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,9 @@ litestar-all = [
     "lite-bootstrap[litestar-sentry,litestar-otl,litestar-logging,litestar-metrics,pyroscope]",
 ]
 faststream = [
-    "faststream",
+    # >=0.6 for faststream._internal.logger.params_storage.ManualLoggerStorage and for
+    # broker.config.logger.params_storage (FastStreamLoggingInstrument swaps and restores it).
+    "faststream>=0.6",
 ]
 faststream-sentry = [
     "lite-bootstrap[faststream,sentry]",
@@ -128,7 +130,10 @@ faststream-all = [
     "lite-bootstrap[sentry,otl,logging,faststream,faststream-metrics,pyroscope]"
 ]
 fastmcp = [
-    "fastmcp",
+    # >=3.0 for fastmcp.server.providers.Provider and FastMCP.add_provider()
+    # (FastMcpBootstrapper registers its teardown through them --
+    # docs/adr/0001-fastmcp-teardown-via-provider-lifespan.md).
+    "fastmcp>=3.0",
 ]
 fastmcp-metrics = [
     "lite-bootstrap[fastmcp]",


### PR DESCRIPTION
Closes #175.

`fastmcp` and `faststream` were the only frameworks declared bare, while both
bootstrappers reach into APIs a version bump can move. An unpinned floor means a
version this repo never tested resolves into a downstream service and fails at
*that* service's bootstrap rather than in our CI.

```toml
faststream>=0.6
fastmcp>=3.0
```

## How the floors were established

Each candidate release was installed into an isolated venv against this source
tree, and the relevant test module run:

| version | result |
| --- | --- |
| `fastmcp` 2.14.7 | fails at import: no `fastmcp.server.providers`, no `FastMCP.add_provider` |
| `fastmcp` 3.0.0 | 21/21 pass |
| `fastmcp` 4.0.3 | 21/21 pass |
| `faststream` 0.5.48 | fails at import: no `faststream._internal.logger`; broker carries no `.config` |
| `faststream` 0.6.0 | 19/19 pass |
| `faststream` 0.7.0 / 0.7.4 | 19/19 pass |

`uv pip install --resolution lowest-direct` on each extra resolves to exactly
3.0.0 and 0.6.0.

## Why `broker.ping(timeout=...)` is not named in the comment

#175 lists it alongside `params_storage` as an internal `FastStreamBootstrapper`
reaches for, and points at `litestar>=2.15` as the precedent for naming the APIs
that forced a floor. `ping(timeout=)` is present in 0.5.48, so it forces no floor
of its own. The litestar comment names two APIs because both genuinely set one
(2.13 and 2.15, "the higher floor wins"); naming `ping` here would misattribute
the 0.6 minimum to an API that has been stable across it.

## What this does not do

Nothing in CI reproduces the lowest-direct check — every job runs
`uv lock --upgrade` and resolves newest — so this declaration, like the four
floors that predate it, is unenforced and will rot the next time a bootstrapper
reaches for a newer API. #210 tracks closing that gap.

Both floors are lower bounds only. For `faststream`, which ships breaking changes
as minor bumps, that constrains only the old half of the failure mode #175
describes; left uncapped to match every other floor in the file, and open for
discussion.