### PR TITLE
chore(coverage): declare the gate in [tool.coverage.report] and measure only in test-ci

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -63,8 +63,7 @@ jobs:
       - run: uv python install ${{ matrix.python-version }}
       - run: uv python pin ${{ matrix.python-version }}
       - run: just install
-      - run: just test . --cov=. --cov-report xml
-
+      - run: just test-ci
   free-threaded:
     runs-on: ubuntu-latest
     strategy:

--- a/justfile
+++ b/justfile
@@ -19,8 +19,11 @@ lint-ci:
 test *args:
     uv run --no-sync pytest {{ args }}
 
+test-ci:
+    uv run --no-sync pytest --cov=. --cov-report term-missing --cov-report xml
+
 test-branch:
-    @just test --cov-branch
+    @just test --cov=. --cov-branch
 
 # Auth via PyPI Trusted Publishing (OIDC); uv publish auto-detects the CI id-token.
 publish:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,11 +189,12 @@ isort.no-lines-before = ["standard-library", "local-folder"]
 "tests/**" = ["S101"]
 
 [tool.pytest.ini_options]
-addopts = "--cov=. --cov-report term-missing --cov-fail-under=100"
+addopts = ""
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.coverage.report]
+fail_under = 100
 exclude_also = [
     "if typing.TYPE_CHECKING:",
     "except ImportError:"


### PR DESCRIPTION
## Summary

Converges the coverage gate on the [modern-python standard, section 5](https://modern-python.org/standard/#5-tests-and-coverage): the 100 % gate is declared once as `[tool.coverage.report] fail_under = 100`, and coverage is measured only by `just test-ci` (and `test-branch`), never on every run through pytest `addopts`.

pytest-cov reads `fail_under` from the coverage config when no `--cov-fail-under` flag is given and applies it whenever coverage is measured, so the gate fires in `test-ci` exactly as before and a targeted `just test` run stays gate-free. coverage special-cases 100: the total must really be 100, no rounding.

## Changes

- `pyproject.toml`: `fail_under = 100` under `[tool.coverage.report]`; any `--cov*` flags removed from `addopts`.
- `justfile`: `test-ci` measures coverage and writes the XML report without the flag; `test-branch` likewise. Where `test-ci` did not exist it is added, and CI now calls it.
- `.github/workflows/_checks.yml` (where present): the pytest step runs `just test-ci`.

## Checklist

- [x] Lint and format pass (`ruff`) — config and recipes only
- [x] Type check passes (`ty`) — no Python changed
- [x] Tests pass and new behavior is covered — CI runs `just test-ci`, which is the gate
- [x] Build succeeds — no packaging change
- [x] Repo metadata stays consistent across the three surfaces — untouched
