### PR TITLE
feat: declare minimum compatible version for typing-extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ dependencies = [
     # Runtime use: `typing_extensions.Self` (base.py) and `typing_extensions.TypedDict`
     # (healthchecks) — the latter is required by pydantic/FastAPI on Python < 3.12
     # (`typing.TypedDict` is rejected there). Pure Python, so ft-friendly.
-    "typing-extensions",
+    # >=4.0 for `Self`; >=4.6 because 4.4 and 4.5 raise on import under Python >=3.12
+    # (they subclass `typing.TypeVar`). The higher floor wins.
+    "typing-extensions>=4.6",
 ]
 
 [project.urls]


### PR DESCRIPTION
Part of #213.

Core's only runtime dependency was declared bare. A bare install resolved at its
floor gets `typing-extensions==3.6.2` and does not import:

```
ImportError: cannot import name 'GenericMeta' from 'typing'
  at lite_bootstrap/instruments/base.py:4
```

[ADR-0007](https://github.com/modern-python/lite-bootstrap/blob/main/docs/adr/0007-core-declares-typing-extensions.md)
argues this dependency is load-bearing and names both uses; the floor those uses
imply was never written down.

```toml
typing-extensions>=4.6
```

## How the floor was established

Bare core (`uv pip install --no-deps .`) plus one pinned `typing-extensions`,
`import lite_bootstrap`, on every interpreter in the CI matrix:

| typing-extensions | 3.10 | 3.11 | 3.12 | 3.13 | 3.14 |
| --- | --- | --- | --- | --- | --- |
| 3.10.0.2 | fail | fail | fail | fail | pass |
| 4.0.0 - 4.3.0 | pass | pass | pass | pass | pass |
| 4.4.0, 4.5.0 | pass | pass | fail | fail | fail |
| 4.6.0 and later | pass | pass | pass | pass | pass |

Two independent constraints, so the comment follows the `litestar>=2.15` idiom of
naming both and letting the higher one win:

- Below 4.0: `AttributeError: module 'typing_extensions' has no attribute 'Self'`,
  raised while evaluating the return annotations on `BaseConfig.from_dict` and
  `from_object`.
- 4.4.0 and 4.5.0: `TypeError: type 'typing.TypeVar' is not an acceptable base
  type`, raised inside `typing_extensions` itself on Python >=3.12, which made
  `typing.TypeVar` non-subclassable. Neither release declares a `Requires-Python`
  ceiling, so a resolver on 3.12+ will pick them under a `>=4.0` floor. That is
  what rules out the simpler declaration.

After the change, `uv pip install --resolution lowest-direct .` resolves
`typing-extensions==4.6.0` and imports clean on 3.10 through 3.14.

## The 3.14 column

3.10.0.2 passes on 3.14 alone because PEP 649 defers annotation evaluation there,
so the missing `Self` is never looked up at import. The `TypedDict` base class is
still evaluated eagerly and 3.10.0.2 provides it. The floor is set by the
interpreters where the annotation is evaluated, not by the one where it is not.

## What this does not do

No test accompanies the declaration, matching #211: the claim is about resolution,
which nothing in the suite exercises. `just test-ci` (277 passed, 100% coverage)
and `just lint-ci` pass unchanged, and `uv.lock` is untouched because every extra
already pulls `typing-extensions` far above 4.6 transitively. #210 is the job that
would hold this floor; until it exists the declaration is verified by the table
above and nothing else.

Eleven bare requirements remain, tracked in #213.
